### PR TITLE
Better clay quarto preview

### DIFF
--- a/.github/workflows/render-and-publish.yml
+++ b/.github/workflows/render-and-publish.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: cljdeps-
 
       - name: Build the content notebooks
-        run: clojure -M:clay -A:markdown:ci
+        run: clojure -M:clay -A:markdown
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/clay.edn
+++ b/clay.edn
@@ -13,6 +13,7 @@
 
  ;; aliases
  :markdown
- {:render         true
-  :format         [:quarto :html]
-  :run-quarto     false}}
+ {:render           true
+  :base-target-path "site"
+  :format           [:quarto :html]
+  :run-quarto       false}}

--- a/clay.edn
+++ b/clay.edn
@@ -1,20 +1,18 @@
-{:base-target-path "temp"
- :base-source-path "src"
- :subdirs-to-sync  ["src"]
- :remote-repo      {:git-url "https://github.com/ClojureCivitas/clojurecivitas.github.io"
-                    :branch  "main"}
- :hide-info-line   true
- :hide-ui-header   true
- :config/transform civitas.db/expand-authors
+{:base-target-path   "temp"
+ :base-source-path   "src"
+ :quarto-target-path "site"
+ :quarto             []
+ :subdirs-to-sync    ["src"]
+ :keep-sync-root     false
+ :flatten-targets    false
+ :remote-repo        {:git-url "https://github.com/ClojureCivitas/clojurecivitas.github.io"
+                      :branch  "main"}
+ :hide-ui-header     true
+ :config/transform   civitas.db/expand-authors
  ;; :use-kindly-render true
 
  ;; aliases
  :markdown
- {:render           true
-  :base-target-path "site"
-  :format           [:quarto :html]
-  :run-quarto       false
-  :hide-info-line   false
-  :quarto           []
-  :flatten-targets  false
-  :keep-sync-root   false}}
+ {:render         true
+  :format         [:quarto :html]
+  :run-quarto     false}}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   clj-thamil/clj-thamil                       {:mvn/version "0.2.0"}
   org.scicloj/clay                            {#_#_:mvn/version "2-beta46"
                                                :git/url "https://github.com/scicloj/clay.git"
-                                               :git/sha "759d5e56b8e754623d9f33e58cfcc15d22543f28"}
+                                               :git/sha "1202c539f8d1bdee64752bb35e82ab489f5af1cd"}
   org.eclipse.elk/org.eclipse.elk.core        {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph       {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph.json  {:mvn/version "0.10.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   clj-thamil/clj-thamil                       {:mvn/version "0.2.0"}
   org.scicloj/clay                            {#_#_:mvn/version "2-beta46"
                                                :git/url "https://github.com/scicloj/clay.git"
-                                               :git/sha "14d92108fc66150cc4ae574cb1d85667111616a8"}
+                                               :git/sha "84c9aa79e8e82293e7c80ee81d544d3b064202f4"}
   org.eclipse.elk/org.eclipse.elk.core        {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph       {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph.json  {:mvn/version "0.10.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   clj-thamil/clj-thamil                       {:mvn/version "0.2.0"}
   org.scicloj/clay                            {#_#_:mvn/version "2-beta46"
                                                :git/url "https://github.com/scicloj/clay.git"
-                                               :git/sha "1202c539f8d1bdee64752bb35e82ab489f5af1cd"}
+                                               :git/sha "14d92108fc66150cc4ae574cb1d85667111616a8"}
   org.eclipse.elk/org.eclipse.elk.core        {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph       {:mvn/version "0.10.0"}
   org.eclipse.elk/org.eclipse.elk.graph.json  {:mvn/version "0.10.0"}

--- a/site/scicloj/clay/skip_if_unchanged_example.qmd
+++ b/site/scicloj/clay/skip_if_unchanged_example.qmd
@@ -26,7 +26,7 @@ image: skip-if-unchanged.jpg
 .clay-side-by-side .sourceCode {margin: 0}
 .clay-side-by-side {margin: 1em 0}
 </style>
-<script src="skip_if_unchanged_example.qmd_files/md-default0.js" type="text/javascript"></script><script src="skip_if_unchanged_example.qmd_files/md-default1.js" type="text/javascript"></script>
+<script src="skip_if_unchanged_example_files/md-default0.js" type="text/javascript"></script><script src="skip_if_unchanged_example_files/md-default1.js" type="text/javascript"></script>
 
 ::: {.sourceClojure}
 ```clojure


### PR DESCRIPTION
Using the new branch of clay,
now you can run the `Clay Make File Quarto` editor integration and it will look like the real site, and you can run `quarto preview site` separately and see the updates without interfering.