### PR TITLE
Update fastmath to 3.0.0-alpha3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,7 @@
   org.lwjgl/lwjgl-stb$natives-linux           {:mvn/version "3.3.6"}
   org.lwjgl/lwjgl-stb$natives-windows         {:mvn/version "3.3.6"}
   org.lwjgl/lwjgl-stb$natives-macos           {:mvn/version "3.3.6"}
+  generateme/fastmath                         {:mvn/version "3.0.0-alpha3"}
   clj-http/clj-http                           {:mvn/version "3.13.1"}}
 
  :aliases

--- a/site/opengl_visualization/main.qmd
+++ b/site/opengl_visualization/main.qmd
@@ -37,7 +37,8 @@ First we need to get some libraries and we can use add-libs to fetch them.
            'org.lwjgl/lwjgl-glfw                 {:mvn/version "3.3.6"}
            'org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.3.6"}
            'org.lwjgl/lwjgl-stb                  {:mvn/version "3.3.6"}
-           'org.lwjgl/lwjgl-stb$natives-linux    {:mvn/version "3.3.6"}})
+           'org.lwjgl/lwjgl-stb$natives-linux    {:mvn/version "3.3.6"}
+           'generateme/fastmath                  {:mvn/version "3.0.0-alpha3"}})
 (require '[clojure.java.io :as io])
 (import '[javax.imageio ImageIO]
         '[org.lwjgl BufferUtils]
@@ -177,7 +178,7 @@ Next we need to set up OpenGL rendering for this window.
 
 ::: {.printedClojure}
 ```clojure
-#object[org.lwjgl.opengl.GLCapabilities 0x3bd92313 "org.lwjgl.opengl.GLCapabilities@3bd92313"]
+#object[org.lwjgl.opengl.GLCapabilities 0x30f1b3c2 "org.lwjgl.opengl.GLCapabilities@30f1b3c2"]
 
 ```
 :::

--- a/src/opengl_visualization/main.clj
+++ b/src/opengl_visualization/main.clj
@@ -30,7 +30,8 @@
 ;;            'org.lwjgl/lwjgl-glfw                 {:mvn/version "3.3.6"}
 ;;            'org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.3.6"}
 ;;            'org.lwjgl/lwjgl-stb                  {:mvn/version "3.3.6"}
-;;            'org.lwjgl/lwjgl-stb$natives-linux    {:mvn/version "3.3.6"}})
+;;            'org.lwjgl/lwjgl-stb$natives-linux    {:mvn/version "3.3.6"}
+;;            'generateme/fastmath                  {:mvn/version "3.0.0-alpha3"}})
 ;; (require '[clojure.java.io :as io])
 ;; (import '[javax.imageio ImageIO]
 ;;         '[org.lwjgl BufferUtils]


### PR DESCRIPTION
Hi, as suggested I added fastmath 3.0.0-alpha3 without exclusions and regenerated the OpenGL article.