### PR TITLE
Rename `bb site-preview` to `bb preview`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
 {:tasks
- {site-preview {:doc "Build site with Quarto and preview"
-                :task (do (clojure "-M:clay -A:markdown")
-                          (shell "quarto preview site"))}}}
+ {preview
+  {:doc "Build site with Quarto and preview"
+   :task (do (clojure "-M:clay -A:markdown")
+             (shell "quarto preview site"))}}}


### PR DESCRIPTION
Goal: easier to remember, easier to type. When we have a _single_ task, we can afford to keep it simple. Suggested by @timothypratley in #112.