### PR TITLE
Add pyodide + scittle example

### DIFF
--- a/src/scittle/pyodide/code_editor.cljs
+++ b/src/scittle/pyodide/code_editor.cljs
@@ -1,0 +1,108 @@
+(ns scittle.pyodide.code-editor
+  (:require
+   [reagent.core :as r]
+   [reagent.dom :as rdom]
+   [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Interactive Python Code Editor
+;; ============================================================================
+
+(defonce code (r/atom "# Try some Python code!\nimport math\n\nradius = 5\narea = math.pi * radius ** 2\nprint(f'Circle area: {area:.2f}')"))
+
+(defonce output (r/atom ""))
+
+(defonce running? (r/atom false))
+
+(defn run-code!
+  []
+  (reset! running? true)
+  (reset! output "Running...")
+  (-> (pyodide/run-python
+       (str "import sys\n"
+            "from io import StringIO\n"
+            "sys.stdout = StringIO()\n"
+            @code "\n"
+            "sys.stdout.getvalue()"))
+      (.then (fn [result]
+               (reset! output (if (empty? result)
+                                "✓ Code executed successfully (no output)"
+                                result))
+               (reset! running? false)))
+      (.catch (fn [err]
+                (reset! output (str "❌ Error:\n" (.-message err)))
+                (reset! running? false)))))
+
+(defn main-component
+  []
+  [:div {:style {:max-width "768px"
+                 :margin "0 auto"
+                 :padding "24px"}}
+   [:h2 {:style {:font-size "24px"
+                 :font-weight "bold"
+                 :margin-bottom "16px"}}
+    "Python Code Editor 💻"]
+
+   [:div {:style {:background-color "#FEF3C7"
+                  :border-left "4px solid #F59E0B"
+                  :padding "16px"
+                  :margin-bottom "24px"}}
+    [:p {:style {:font-size "14px" :color "#374151"}}
+     "Write Python code below and click Run to execute it in your browser!"]]
+
+   ;; Code editor
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"}}
+     "Python Code:"]
+    [:textarea {:value @code
+                :on-change #(reset! code (.. % -target -value))
+                :rows 10
+                :style {:width "100%"
+                        :padding "12px"
+                        :font-family "monospace"
+                        :font-size "14px"
+                        :border "2px solid #D1D5DB"
+                        :border-radius "6px"
+                        :resize "vertical"}}]]
+
+   ;; Run button
+   [:button {:style {:width "100%"
+                     :padding "12px 24px"
+                     :background-color (if @running? "#9CA3AF" "#10B981")
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :font-size "16px"
+                     :cursor (if @running? "not-allowed" "pointer")
+                     :margin-bottom "16px"}
+             :on-click run-code!
+             :disabled (or @running? (not (pyodide/ready?)))}
+    (cond
+      @running? "Running..."
+      (not (pyodide/ready?)) "Initialize Pyodide First"
+      :else "Run Code")]
+
+   ;; Output display
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"}}
+     "Output:"]
+    [:pre {:style {:background-color "#F9FAFB"
+                   :color "#1F2937"
+                   :padding "16px"
+                   :border-radius "6px"
+                   :border "2px solid #E5E7EB"
+                   :font-family "monospace"
+                   :font-size "14px"
+                   :min-height "120px"
+                   :white-space "pre-wrap"
+                   :overflow-x "auto"}}
+     @output]]])
+
+(rdom/render [main-component] (js/document.getElementById "code-editor-demo"))

--- a/src/scittle/pyodide/code_executor.cljs
+++ b/src/scittle/pyodide/code_executor.cljs
@@ -1,0 +1,238 @@
+(ns scittle.pyodide.code-executor
+  (:require
+   [reagent.core :as r]
+   [reagent.dom :as rdom]
+   [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Interactive Python Code Executor
+;; Uses shared pyodide-bridge for Pyodide state
+;; ============================================================================
+
+;; Local state - only UI/output state, Pyodide state is in bridge
+(defonce code (r/atom "# Write your Python code here\nprint('Hello, World!')\n\n# Try some calculations\nresult = 2 + 2\nprint(f'2 + 2 = {result}')"))
+
+(defonce output (r/atom ""))
+
+(defonce error (r/atom nil))
+
+(defonce executing? (r/atom false))
+
+;; ============================================================================
+;; Pyodide Functions
+;; ============================================================================
+
+(defn init-pyodide!
+  []
+  (-> (pyodide/init!)
+      (.then (fn [_]
+               (reset! output "Pyodide loaded! Ready to execute Python code.")
+               (js/console.log "✓ Pyodide initialized")))
+      (.catch (fn [err]
+                (reset! error (.-message err))
+                (js/console.error "Failed to load Pyodide:" err)))))
+
+(defn capture-output
+  "Setup Python stdout capture"
+  [pyodide-inst]
+  (.runPython pyodide-inst "
+import sys
+import io
+
+class OutputCapture:
+    def __init__(self):
+        self.output = []
+
+    def write(self, text):
+        if text and text != '\\n':
+            self.output.append(text)
+
+    def flush(self):
+        pass
+
+    def get_output(self):
+        return ''.join(self.output)
+
+    def clear(self):
+        self.output = []
+
+_output_capture = OutputCapture()
+sys.stdout = _output_capture
+sys.stderr = _output_capture
+"))
+
+(defn run-python-code
+  []
+  (when-let [pyodide-inst (pyodide/get-instance)]
+    (reset! executing? true)
+    (reset! error nil)
+    (-> ;; Clear previous output
+     (js/Promise.resolve
+      (.runPython pyodide-inst "_output_capture.clear()"))
+     (.then (fn []
+              ;; Execute user code
+              (.runPythonAsync pyodide-inst @code)))
+     (.then (fn [result]
+              ;; Get captured output
+              (let [captured-output (.runPython pyodide-inst "_output_capture.get_output()")
+                    result-str (str result)]
+                (reset! output
+                        (str captured-output
+                             (when (and (seq result-str)
+                                        (not= result-str "undefined")
+                                        (not= result-str "None"))
+                               (str "\n→ " result-str))))
+                (reset! executing? false))))
+     (.catch (fn [err]
+               (reset! error (.-message err))
+               (reset! output "")
+               (reset! executing? false))))))
+
+;; ============================================================================
+;; UI Components
+;; ============================================================================
+
+(defn status-indicator
+  []
+  (let [status (pyodide/status)]
+    [:div.flex.items-center.justify-between.mb-4
+     [:div.flex.items-center.gap-2
+      [:span.text-sm.font-semibold "Status:"]
+      [:span.px-3.py-1.rounded-full.text-xs.font-medium
+       (case status
+         :not-started {:class "bg-gray-200 text-gray-700"
+                       :text "Not Initialized"}
+         :loading {:class "bg-blue-200 text-blue-700 animate-pulse"
+                   :text "Loading..."}
+         :ready {:class "bg-green-200 text-green-700"
+                 :text "Ready"}
+         :error {:class "bg-red-200 text-red-700"
+                 :text "Error"})]]
+
+     (when (= status :ready)
+       [:div.flex.gap-2
+        [:button.px-4.py-2.bg-green-500.text-white.rounded.hover:bg-green-600.disabled:opacity-50.text-sm.font-medium
+         {:on-click run-python-code
+          :disabled @executing?}
+         (if @executing?
+           "Running..."
+           "▶ Run Code")]
+
+        [:button.px-3.py-2.bg-gray-500.text-white.rounded.hover:bg-gray-600.text-sm
+         {:on-click #(do (reset! output "")
+                         (reset! error nil))}
+         "Clear Output"]])]))
+
+(defn code-editor
+  []
+  (let [status (pyodide/status)]
+    [:div.mb-4
+     [:label.block.text-sm.font-semibold.mb-2.text-gray-700
+      "Python Code Editor"]
+     [:textarea.w-full.h-64.p-4.border-2.border-gray-300.rounded-lg.font-mono.text-sm.focus:outline-none.focus:border-blue-500
+      {:value @code
+       :on-change #(reset! code (.. % -target -value))
+       :disabled (not= status :ready)
+       :placeholder "Write your Python code here..."
+       :style {:background-color (if (= status :ready) "#ffffff" "#f5f5f5")
+               :resize "vertical"}}]]))
+
+(defn output-display
+  []
+  [:div.mb-4
+   [:label.block.text-sm.font-semibold.mb-2.text-gray-700
+    "Output"]
+   (if @error
+     [:div.bg-red-50.border-2.border-red-300.rounded-lg.p-4
+      [:div.text-xs.font-semibold.text-red-700.mb-2 "Error:"]
+      [:pre.text-sm.text-red-800.whitespace-pre-wrap.font-mono
+       @error]]
+     [:div.bg-gray-900.text-green-400.rounded-lg.p-4.min-h-32.font-mono.text-sm.whitespace-pre-wrap
+      (if (seq @output)
+        @output
+        [:span.text-gray-500 "Output will appear here..."])])])
+
+(defn example-snippets
+  []
+  (let [status (pyodide/status)]
+    [:div.mb-4
+     [:label.block.text-sm.font-semibold.mb-2.text-gray-700
+      "Quick Examples (click to load)"]
+     [:div.grid.grid-cols-2.md:grid-cols-3.gap-2
+      [:button.px-3.py-2.bg-blue-100.text-blue-700.rounded.hover:bg-blue-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# Basic arithmetic\nfor i in range(1, 6):\n    print(f'{i} squared = {i**2}')")
+        :disabled (not= status :ready)}
+       "Loop Example"]
+      [:button.px-3.py-2.bg-purple-100.text-purple-700.rounded.hover:bg-purple-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# List comprehension\nnumbers = [1, 2, 3, 4, 5]\nsquares = [n**2 for n in numbers]\nprint(f'Numbers: {numbers}')\nprint(f'Squares: {squares}')")
+        :disabled (not= status :ready)}
+       "List Comprehension"]
+      [:button.px-3.py-2.bg-green-100.text-green-700.rounded.hover:bg-green-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# Function definition\ndef fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)\n\nfor i in range(10):\n    print(f'fib({i}) = {fibonacci(i)}')")
+        :disabled (not= status :ready)}
+       "Fibonacci"]
+      [:button.px-3.py-2.bg-yellow-100.text-yellow-700.rounded.hover:bg-yellow-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# Dictionary operations\ndata = {'name': 'Alice', 'age': 30, 'city': 'NYC'}\nfor key, value in data.items():\n    print(f'{key}: {value}')")
+        :disabled (not= status :ready)}
+       "Dictionary"]
+      [:button.px-3.py-2.bg-pink-100.text-pink-700.rounded.hover:bg-pink-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# String manipulation\ntext = 'Hello Python World'\nprint(f'Original: {text}')\nprint(f'Upper: {text.upper()}')\nprint(f'Words: {text.split()}')\nprint(f'Reversed: {text[::-1]}')")
+        :disabled (not= status :ready)}
+       "Strings"]
+      [:button.px-3.py-2.bg-indigo-100.text-indigo-700.rounded.hover:bg-indigo-200.text-xs.disabled:opacity-50
+       {:on-click #(reset! code "# Classes\nclass Dog:\n    def __init__(self, name):\n        self.name = name\n    \n    def bark(self):\n        return f'{self.name} says Woof!'\n\ndog = Dog('Rex')\nprint(dog.bark())")
+        :disabled (not= status :ready)}
+       "Classes"]]]))
+
+(defn main-component
+  []
+  (let [status (pyodide/status)
+        pyodide-error (pyodide/get-error)]
+    [:div.max-w-4xl.mx-auto.p-6
+     [:h2.text-3xl.font-bold.mb-2 "Interactive Python Executor 🐍"]
+     [:p.text-gray-600.mb-6
+      "Write and execute Python code directly in your browser. No server required!"]
+
+     (when (= status :not-started)
+       [:div.bg-yellow-50.border-l-4.border-yellow-500.p-4.mb-6
+        [:p.text-sm.text-gray-700.mb-3
+         "Click the button below to initialize Pyodide. This will download ~8MB of Python runtime (one-time load)."]
+        [:button.px-6.py-3.bg-gradient-to-r.from-blue-500.to-purple-600.text-white.rounded-lg.font-semibold.hover:from-blue-600.hover:to-purple-700
+         {:on-click #(do (init-pyodide!)
+                         ;; Setup output capture after init
+                         (js/setTimeout
+                          (fn []
+                            (when-let [pyodide-inst (pyodide/get-instance)]
+                              (capture-output pyodide-inst)))
+                          1000))}
+         "Initialize Python Runtime"]])
+     (when (= status :loading)
+       [:div.bg-blue-50.border-l-4.border-blue-500.p-4.mb-6
+        [:div.flex.items-center.gap-3
+         [:div.animate-spin.rounded-full.h-6.w-6.border-b-2.border-blue-500]
+         [:p.text-sm.text-gray-700
+          "Loading Pyodide... This may take a few seconds on first load."]]])
+     (when (= status :ready)
+       [:div
+        [status-indicator]
+        [example-snippets]
+        [code-editor]
+        [output-display]
+        [:div.bg-gray-50.border.border-gray-200.rounded-lg.p-4.mt-6
+         [:h3.text-sm.font-semibold.mb-2.text-gray-700 "Features:"]
+         [:ul.text-xs.text-gray-600.space-y-1.list-disc.list-inside
+          [:li "Full Python 3.11 interpreter running in WebAssembly"]
+          [:li "Standard library available (math, random, datetime, etc.)"]
+          [:li "Captures print() output and return values"]
+          [:li "Syntax errors and exceptions shown inline"]
+          [:li "All execution happens client-side in your browser"]]]])
+     (when (= status :error)
+       [:div.bg-red-50.border-l-4.border-red-500.p-4.mb-6
+        [:p.text-sm.text-red-700.mb-2 "Failed to load Pyodide:"]
+        [:p.text-xs.text-red-600.font-mono pyodide-error]])]))
+
+;; ============================================================================
+;; Mount - Render when script loads
+;; ============================================================================
+
+(rdom/render [main-component] (js/document.getElementById "python-executor-demo"))

--- a/src/scittle/pyodide/data_visualization.cljs
+++ b/src/scittle/pyodide/data_visualization.cljs
@@ -1,0 +1,289 @@
+(ns scittle.pyodide.data-visualization
+  (:require [reagent.core :as r]
+            [reagent.dom :as rdom]
+            [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Matplotlib Data Visualization Demo
+;; ============================================================================
+
+(defonce code (r/atom "# Line Chart - Monthly Sales Data
+import numpy as np
+
+months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']
+sales = [45, 52, 48, 65, 70, 68]
+expenses = [30, 35, 33, 40, 42, 41]
+
+plt.figure(figsize=(10, 6))
+plt.plot(months, sales, marker='o', linewidth=2, label='Sales', color='#10B981')
+plt.plot(months, expenses, marker='s', linewidth=2, label='Expenses', color='#EF4444')
+plt.xlabel('Month', fontsize=12)
+plt.ylabel('Amount ($K)', fontsize=12)
+plt.title('Monthly Sales vs Expenses', fontsize=14, fontweight='bold')
+plt.legend()
+plt.grid(True, alpha=0.3)"))
+
+(defonce output-image (r/atom nil))
+
+(defonce output-text (r/atom "Click 'Generate Chart' to visualize your data"))
+
+(defonce running? (r/atom false))
+
+(defonce matplotlib-loaded? (r/atom false))
+
+;; Chart examples
+(def chart-examples
+  {:line-chart "# Line Chart - Monthly Sales Data
+import numpy as np
+
+months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']
+sales = [45, 52, 48, 65, 70, 68]
+expenses = [30, 35, 33, 40, 42, 41]
+
+plt.figure(figsize=(10, 6))
+plt.plot(months, sales, marker='o', linewidth=2, label='Sales', color='#10B981')
+plt.plot(months, expenses, marker='s', linewidth=2, label='Expenses', color='#EF4444')
+plt.xlabel('Month', fontsize=12)
+plt.ylabel('Amount ($K)', fontsize=12)
+plt.title('Monthly Sales vs Expenses', fontsize=14, fontweight='bold')
+plt.legend()
+plt.grid(True, alpha=0.3)"
+
+   :bar-chart "# Bar Chart - Product Sales Comparison
+categories = ['Product A', 'Product B', 'Product C', 'Product D', 'Product E']
+values = [75, 62, 88, 45, 92]
+colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6']
+
+plt.figure(figsize=(10, 6))
+plt.bar(categories, values, color=colors, alpha=0.8)
+plt.xlabel('Products', fontsize=12)
+plt.ylabel('Sales (Units)', fontsize=12)
+plt.title('Product Sales Comparison', fontsize=14, fontweight='bold')
+plt.ylim(0, 100)
+plt.grid(axis='y', alpha=0.3)"
+
+   :scatter-plot "# Scatter Plot - Height vs Weight
+import numpy as np
+
+np.random.seed(42)
+heights = np.random.normal(170, 10, 50)
+weights = heights * 0.6 + np.random.normal(0, 5, 50)
+
+plt.figure(figsize=(10, 6))
+plt.scatter(heights, weights, alpha=0.6, c='#8B5CF6', s=100, edgecolors='white', linewidth=1.5)
+plt.xlabel('Height (cm)', fontsize=12)
+plt.ylabel('Weight (kg)', fontsize=12)
+plt.title('Height vs Weight Distribution', fontsize=14, fontweight='bold')
+plt.grid(True, alpha=0.3)"
+
+   :pie-chart "# Pie Chart - Market Share
+labels = ['Company A', 'Company B', 'Company C', 'Company D', 'Others']
+sizes = [35, 25, 20, 12, 8]
+colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#9CA3AF']
+explode = (0.1, 0, 0, 0, 0)
+
+plt.figure(figsize=(10, 6))
+plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+        autopct='%1.1f%%', shadow=True, startangle=90)
+plt.title('Market Share Distribution', fontsize=14, fontweight='bold')
+plt.axis('equal')"})
+
+(defn load-matplotlib!
+  []
+  (js/console.log "🔍 Starting matplotlib load check...")
+  (js/console.log "Pyodide ready?" (pyodide/ready?))
+  (when (pyodide/ready?)
+    (js/console.log "✓ Pyodide is ready, loading matplotlib...")
+    (reset! output-text "Loading matplotlib...")
+    (-> (pyodide/load-packages "matplotlib")
+        (.then (fn [result]
+                 (js/console.log "✓ Matplotlib loaded successfully!" result)
+                 (reset! matplotlib-loaded? true)
+                 (reset! output-text "Matplotlib ready! Click 'Generate Chart' to visualize")))
+        (.catch (fn [err]
+                  (js/console.error "✗ Failed to load matplotlib:" err)
+                  (reset! output-text (str "Error loading matplotlib: " (.-message err))))))))
+
+(defn generate-chart!
+  []
+  (when @matplotlib-loaded?
+    (reset! running? true)
+    (reset! output-text "Generating chart...")
+    (reset! output-image nil)
+    (-> (pyodide/run-python-with-plot @code)
+        (.then (fn [base64-img]
+                 (reset! output-image base64-img)
+                 (reset! output-text "")
+                 (reset! running? false)))
+        (.catch (fn [err]
+                  (reset! output-text (str "Error:\n" (.-message err)))
+                  (reset! output-image nil)
+                  (reset! running? false))))))
+
+(defn load-example!
+  [example-key]
+  (reset! code (get chart-examples example-key))
+  (reset! output-image nil)
+  (reset! output-text "Example loaded. Click 'Generate Chart' to visualize"))
+
+(defn main-component
+  []
+  [:div {:style {:max-width "1024px"
+                 :margin "0 auto"
+                 :padding "24px"}}
+   [:h2 {:style {:font-size "28px"
+                 :font-weight "bold"
+                 :margin-bottom "8px"
+                 :color "#111827"}}
+    "📊 Data Visualization with Matplotlib"]
+   [:p {:style {:color "#6B7280"
+                :margin-bottom "24px"
+                :font-size "16px"}}
+    "Create beautiful charts and visualizations using Python's matplotlib library, running entirely in your browser!"]
+   ;; Info banner
+   [:div {:style {:background-color (if @matplotlib-loaded? "#D1FAE5" "#DBEAFE")
+                  :border-left (str "4px solid " (if @matplotlib-loaded? "#10B981" "#3B82F6"))
+                  :padding "16px"
+                  :margin-bottom "24px"
+                  :border-radius "4px"}}
+    [:p {:style {:font-size "14px"
+                 :color (if @matplotlib-loaded? "#065F46" "#1E40AF")
+                 :margin "0"}}
+     (if @matplotlib-loaded?
+       "✓ Matplotlib is loaded and ready!"
+       "Loading matplotlib... This may take a moment on first load.")]]
+   ;; Example buttons
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Quick Examples:"]
+    [:div {:style {:display "flex"
+                   :gap "8px"
+                   :flex-wrap "wrap"}}
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :line-chart)}
+      "📈 Line Chart"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :bar-chart)}
+      "📊 Bar Chart"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :scatter-plot)}
+      "⚫ Scatter Plot"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :pie-chart)}
+      "🥧 Pie Chart"]]]
+   ;; Code editor
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Python Code (Matplotlib):"]
+    [:textarea {:value @code
+                :on-change #(reset! code (.. % -target -value))
+                :rows 15
+                :style {:width "100%"
+                        :padding "12px"
+                        :font-family "monospace"
+                        :font-size "14px"
+                        :border "2px solid #D1D5DB"
+                        :border-radius "6px"
+                        :resize "vertical"
+                        :background-color "#FFFFFF"
+                        :color "#111827"}}]]
+   ;; Generate button
+   [:button {:style {:width "100%"
+                     :padding "14px 24px"
+                     :background-color (cond
+                                         @running? "#9CA3AF"
+                                         (not @matplotlib-loaded?) "#9CA3AF"
+                                         :else "#3B82F6")
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :font-size "16px"
+                     :cursor (if (or @running? (not @matplotlib-loaded?))
+                               "not-allowed"
+                               "pointer")
+                     :margin-bottom "24px"}
+             :on-click generate-chart!
+             :disabled (or @running? (not @matplotlib-loaded?))}
+    (cond
+      @running? "Generating Chart..."
+      (not @matplotlib-loaded?) "Loading Matplotlib..."
+      :else "📊 Generate Chart")]
+   ;; Output area
+   [:div {:style {:background-color "#FFFFFF"
+                  :border "2px solid #E5E7EB"
+                  :border-radius "8px"
+                  :padding "20px"
+                  :min-height "400px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "12px"
+                     :color "#374151"}}
+     "Visualization Output:"]
+    (if @output-image
+      [:div {:style {:text-align "center"}}
+       [:img {:src (str "data:image/png;base64," @output-image)
+              :alt "Generated Chart"
+              :style {:max-width "100%"
+                      :height "auto"
+                      :border-radius "4px"
+                      :box-shadow "0 2px 8px rgba(0,0,0,0.1)"}}]]
+      [:div {:style {:padding "40px"
+                     :text-align "center"
+                     :color "#6B7280"
+                     :font-size "14px"}}
+       [:p {:style {:margin "0"}} @output-text]])]])
+
+;; Initialize matplotlib on mount - with retry logic
+(defonce init-done?
+  (do
+    (js/console.log "🚀 Data visualization component mounted")
+    (letfn [(try-load []
+              (if (pyodide/ready?)
+                (do
+                  (js/console.log "✓ Pyodide ready, loading matplotlib...")
+                  (load-matplotlib!))
+                (do
+                  (js/console.log "⏳ Pyodide not ready, retrying in 500ms...")
+                  (js/setTimeout try-load 500))))]
+      (js/setTimeout try-load 100))
+    true))
+
+(rdom/render [main-component] (js/document.getElementById "data-visualization-demo"))

--- a/src/scittle/pyodide/hello_python.cljs
+++ b/src/scittle/pyodide/hello_python.cljs
@@ -1,0 +1,180 @@
+(ns scittle.pyodide.hello-python
+  (:require
+   [reagent.core :as r]
+   [reagent.dom :as rdom]
+   [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Simple Pyodide "Hello World" Demo
+;; Uses shared pyodide-bridge for state management
+;; ============================================================================
+
+;; Local state (output only - Pyodide state is in bridge)
+(defonce output (r/atom "Click 'Initialize Pyodide' to start..."))
+
+;; ============================================================================
+;; Pyodide Functions
+;; ============================================================================
+
+(defn init-pyodide!
+  []
+  (js/console.log "Button clicked - starting initialization...")
+  (reset! output "Loading Pyodide... This may take a few seconds...")
+  (try
+    (let [promise (pyodide/init!)]
+      (js/console.log "Got promise from pyodide/init!:" promise)
+      (-> promise
+          (.then (fn [pyodide-inst]
+                   (js/console.log "Pyodide init promise resolved:" pyodide-inst)
+                   (reset! output "✓ Pyodide loaded successfully! Try running Python code below.")))
+          (.catch (fn [err]
+                    (js/console.error "Pyodide init promise rejected:" err)
+                    (reset! output (str "✗ Error loading Pyodide: " (.-message err)))))))
+    (catch :default e
+      (js/console.error "Exception in init-pyodide!:" e)
+      (reset! output (str "✗ Exception: " (.-message e))))))
+
+(defn run-python [code]
+  (if (pyodide/ready?)
+    (-> (pyodide/run-python code)
+        (.then (fn [result]
+                 (reset! output (str "Result: " result))))
+        (.catch (fn [err]
+                  (reset! output (str "Error: " (.-message err))))))
+    (reset! output "Please initialize Pyodide first!")))
+
+;; ============================================================================
+;; UI Components
+;; ============================================================================
+
+(defn status-badge
+  []
+  (let [status (pyodide/status)
+        badge-style (case status
+                      :not-started {:background-color "#E5E7EB" :color "#374151"}
+                      :loading {:background-color "#DBEAFE" :color "#1E40AF"}
+                      :ready {:background-color "#D1FAE5" :color "#065F46"}
+                      :error {:background-color "#FEE2E2" :color "#991B1B"}
+                      {:background-color "#E5E7EB" :color "#374151"})
+        badge-text (case status
+                     :not-started "Not Started"
+                     :loading "Loading..."
+                     :ready "Ready"
+                     :error "Error"
+                     "Unknown")]
+    [:div {:style {:display "flex"
+                   :align-items "center"
+                   :gap "8px"
+                   :margin-bottom "16px"}}
+     [:div {:style {:font-size "14px" :font-weight "600"}} "Pyodide Status:"]
+     [:span {:style (merge {:padding "6px 12px"
+                            :border-radius "9999px"
+                            :font-size "12px"
+                            :font-weight "500"}
+                           badge-style)}
+      badge-text]]))
+
+(defn example-buttons
+  []
+  [:div {:style {:display "grid"
+                 :grid-template-columns "1fr 1fr"
+                 :gap "8px"
+                 :margin-bottom "16px"}}
+   [:button {:style {:padding "8px 16px"
+                     :background-color "#3B82F6"
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :cursor "pointer"
+                     :font-size "14px"}
+             :on-click #(run-python "print('Hello from Python!')")
+             :disabled (not (pyodide/ready?))}
+    "Hello Python"]
+   [:button {:style {:padding "8px 16px"
+                     :background-color "#10B981"
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :cursor "pointer"
+                     :font-size "14px"}
+             :on-click #(run-python "2 + 2")
+             :disabled (not (pyodide/ready?))}
+    "Calculate 2 + 2"]
+   [:button {:style {:padding "8px 16px"
+                     :background-color "#8B5CF6"
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :cursor "pointer"
+                     :font-size "14px"}
+             :on-click #(run-python "import sys\nsys.version")
+             :disabled (not (pyodide/ready?))}
+    "Python Version"]
+   [:button {:style {:padding "8px 16px"
+                     :background-color "#F97316"
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :cursor "pointer"
+                     :font-size "14px"}
+             :on-click #(run-python "list(range(1, 11))")
+             :disabled (not (pyodide/ready?))}
+    "List 1-10"]])
+
+(defn output-display
+  []
+  [:div.bg-gray-900.text-green-400.p-4.rounded-lg.font-mono.text-sm.min-h-24.whitespace-pre-wrap
+   @output])
+
+(defn main-component
+  []
+  [:div {:style {:max-width "768px"
+                 :margin "0 auto"
+                 :padding "24px"}}
+   [:h2 {:style {:font-size "24px"
+                 :font-weight "bold"
+                 :margin-bottom "16px"}}
+    "Hello Python! 🐍"]
+   [:div {:style {:background-color "#EFF6FF"
+                  :border-left "4px solid #3B82F6"
+                  :padding "16px"
+                  :margin-bottom "24px"}}
+    [:p {:style {:font-size "14px" :color "#374151"}}
+     "This demo shows the simplest possible Pyodide integration. "
+     "Click the button below to load the Python interpreter in your browser, "
+     "then try the example buttons!"]]
+   [status-badge]
+   [:button {:style {:width "100%"
+                     :padding "12px 24px"
+                     :background "linear-gradient(to right, #3B82F6, #8B5CF6)"
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "8px"
+                     :font-weight "600"
+                     :font-size "16px"
+                     :cursor "pointer"
+                     :margin-bottom "16px"
+                     :opacity (if (pyodide/is-loading?) "0.5" "1")}
+             :on-click init-pyodide!
+             :disabled (pyodide/is-loading?)}
+    (if (pyodide/is-loading?)
+      "Loading Pyodide..."
+      "Initialize Pyodide")]
+   (when (= (pyodide/status) :ready)
+     [example-buttons])
+   [output-display]
+   (when (= (pyodide/status) :ready)
+     [:div {:style {:margin-top "16px" :font-size "12px" :color "#6B7280"}}
+      [:p "✓ Pyodide is running entirely in your browser"]
+      [:p "✓ No server required"]
+      [:p "✓ Full Python 3.11 interpreter"]])])
+
+;; ============================================================================
+;; Mount - Render when script loads
+;; ============================================================================
+
+(rdom/render [main-component] (js/document.getElementById "hello-python-demo"))

--- a/src/scittle/pyodide/pandas_demo.cljs
+++ b/src/scittle/pyodide/pandas_demo.cljs
@@ -1,0 +1,390 @@
+(ns scittle.pyodide.pandas-demo
+  (:require
+   [reagent.core :as r]
+   [reagent.dom :as rdom]
+   [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Pandas DataFrame Analysis Demo
+;; ============================================================================
+
+(defonce code (r/atom "# Create a sample sales DataFrame
+import pandas as pd
+import numpy as np
+
+# Sample data
+data = {
+    'Product': ['Widget A', 'Widget B', 'Widget C', 'Widget D', 'Widget E'],
+    'Sales': [1200, 800, 1500, 950, 1100],
+    'Profit': [450, 200, 600, 380, 420],
+    'Region': ['North', 'South', 'East', 'West', 'North']
+}
+
+df = pd.DataFrame(data)
+
+# Display as HTML table
+print(df.to_html(index=False, border=0, classes='dataframe'))"))
+
+(defonce output-html (r/atom nil))
+
+(defonce output-text (r/atom "Click 'Run Analysis' to see results"))
+
+(defonce running? (r/atom false))
+
+(defonce pandas-loaded? (r/atom false))
+
+;; Example code snippets
+(def examples
+  {:basic-dataframe "# Create a sample sales DataFrame
+import pandas as pd
+import numpy as np
+
+# Sample data
+data = {
+    'Product': ['Widget A', 'Widget B', 'Widget C', 'Widget D', 'Widget E'],
+    'Sales': [1200, 800, 1500, 950, 1100],
+    'Profit': [450, 200, 600, 380, 420],
+    'Region': ['North', 'South', 'East', 'West', 'North']
+}
+
+df = pd.DataFrame(data)
+
+# Display as HTML table
+print(df.to_html(index=False, border=0, classes='dataframe'))"
+
+   :statistics "# Statistical Analysis
+import pandas as pd
+import numpy as np
+
+# Create sample data
+data = {
+    'Product': ['A', 'B', 'C', 'D', 'E'],
+    'Sales': [1200, 800, 1500, 950, 1100],
+    'Profit': [450, 200, 600, 380, 420],
+    'Margin': [37.5, 25.0, 40.0, 40.0, 38.2]
+}
+
+df = pd.DataFrame(data)
+
+# Get descriptive statistics
+stats = df[['Sales', 'Profit', 'Margin']].describe()
+
+# Display statistics
+print('<h4>Descriptive Statistics:</h4>')
+print(stats.to_html(border=0, classes='dataframe'))
+
+# Show correlations
+print('<h4>Correlation Matrix:</h4>')
+corr = df[['Sales', 'Profit', 'Margin']].corr()
+print(corr.to_html(border=0, classes='dataframe'))"
+
+   :filtering "# Data Filtering and Selection
+import pandas as pd
+
+# Create sample data
+data = {
+    'Product': ['Widget A', 'Widget B', 'Widget C', 'Widget D', 'Widget E'],
+    'Sales': [1200, 800, 1500, 950, 1100],
+    'Profit': [450, 200, 600, 380, 420],
+    'Region': ['North', 'South', 'East', 'West', 'North']
+}
+
+df = pd.DataFrame(data)
+
+# Filter high performers (Sales > 1000)
+high_performers = df[df['Sales'] > 1000]
+
+print('<h4>High Performers (Sales > 1000):</h4>')
+print(high_performers.to_html(index=False, border=0, classes='dataframe'))
+
+# Filter by region
+north_sales = df[df['Region'] == 'North']
+
+print('<h4>North Region Sales:</h4>')
+print(north_sales.to_html(index=False, border=0, classes='dataframe'))"
+
+   :grouping "# GroupBy Analysis
+import pandas as pd
+
+# Create sample data with multiple regions
+data = {
+    'Product': ['A', 'B', 'A', 'B', 'A', 'B', 'C', 'C'],
+    'Region': ['North', 'North', 'South', 'South', 'East', 'East', 'North', 'South'],
+    'Sales': [100, 150, 120, 180, 140, 160, 200, 175],
+    'Profit': [30, 45, 36, 54, 42, 48, 60, 52]
+}
+
+df = pd.DataFrame(data)
+
+print('<h4>Original Data:</h4>')
+print(df.to_html(index=False, border=0, classes='dataframe'))
+
+# Group by Product
+print('<h4>Sales by Product:</h4>')
+product_sales = df.groupby('Product')[['Sales', 'Profit']].sum()
+print(product_sales.to_html(border=0, classes='dataframe'))
+
+# Group by Region
+print('<h4>Sales by Region:</h4>')
+region_sales = df.groupby('Region')[['Sales', 'Profit']].sum()
+print(region_sales.to_html(border=0, classes='dataframe'))"
+
+   :transformations "# Data Transformations
+import pandas as pd
+
+# Create sample data
+data = {
+    'Product': ['Widget A', 'Widget B', 'Widget C', 'Widget D'],
+    'Sales': [1200, 800, 1500, 950],
+    'Cost': [750, 600, 900, 570]
+}
+
+df = pd.DataFrame(data)
+
+# Add calculated columns
+df['Profit'] = df['Sales'] - df['Cost']
+df['Margin %'] = ((df['Profit'] / df['Sales']) * 100).round(1)
+df['Profit Rank'] = df['Profit'].rank(ascending=False).astype(int)
+
+# Sort by profit
+df = df.sort_values('Profit', ascending=False)
+
+print('<h4>Enhanced Sales Report:</h4>')
+print(df.to_html(index=False, border=0, classes='dataframe'))"})
+
+(defn load-pandas!
+  []
+  (js/console.log "🔍 Starting pandas load check...")
+  (js/console.log "Pyodide ready?" (pyodide/ready?))
+  (when (pyodide/ready?)
+    (js/console.log "✓ Pyodide is ready, loading pandas...")
+    (reset! output-text "Loading pandas (this may take 30-60 seconds)...")
+    (-> (pyodide/load-packages "pandas")
+        (.then (fn [result]
+                 (js/console.log "✓ Pandas loaded successfully!" result)
+                 (reset! pandas-loaded? true)
+                 (reset! output-text "Pandas ready! Click 'Run Analysis' to see results")))
+        (.catch (fn [err]
+                  (js/console.error "✗ Failed to load pandas:" err)
+                  (reset! output-text (str "Error loading pandas: " (.-message err))))))))
+
+(defn run-analysis!
+  []
+  (when @pandas-loaded?
+    (reset! running? true)
+    (reset! output-text "Running analysis...")
+    (reset! output-html nil)
+    (-> (pyodide/run-python-with-output @code)
+        (.then (fn [result]
+                 (reset! output-html (str result))
+                 (reset! output-text "")
+                 (reset! running? false)))
+        (.catch (fn [err]
+                  (reset! output-text (str "Error:\n" (.-message err)))
+                  (reset! output-html nil)
+                  (reset! running? false))))))
+
+(defn load-example!
+  [example-key]
+  (reset! code (get examples example-key))
+  (reset! output-html nil)
+  (reset! output-text "Example loaded. Click 'Run Analysis' to see results"))
+
+(defn main-component
+  []
+  [:div {:style {:max-width "1024px"
+                 :margin "0 auto"
+                 :padding "24px"}}
+   [:h2 {:style {:font-size "28px"
+                 :font-weight "bold"
+                 :margin-bottom "8px"
+                 :color "#111827"}}
+    "🐼 DataFrame Analysis with Pandas"]
+   [:p {:style {:color "#6B7280"
+                :margin-bottom "24px"
+                :font-size "16px"}}
+    "Analyze and manipulate data using Python's pandas library for powerful data science workflows in your browser!"]
+   ;; Info banner
+   [:div {:style {:background-color (if @pandas-loaded? "#D1FAE5" "#DBEAFE")
+                  :border-left (str "4px solid " (if @pandas-loaded? "#10B981" "#3B82F6"))
+                  :padding "16px"
+                  :margin-bottom "24px"
+                  :border-radius "4px"}}
+    [:p {:style {:font-size "14px"
+                 :color (if @pandas-loaded? "#065F46" "#1E40AF")
+                 :margin "0"}}
+     (if @pandas-loaded?
+       "✓ Pandas is loaded and ready!"
+       "Loading pandas... This may take 30-60 seconds on first load (pandas is ~15MB).")]]
+   ;; Example buttons
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Quick Examples:"]
+    [:div {:style {:display "flex"
+                   :gap "8px"
+                   :flex-wrap "wrap"}}
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :basic-dataframe)}
+      "📋 Basic DataFrame"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :statistics)}
+      "📊 Statistics"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :filtering)}
+      "🔍 Filtering"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :grouping)}
+      "📈 Grouping"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :transformations)}
+      "🔄 Transformations"]]]
+   ;; Code editor
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Python Code (Pandas):"]
+    [:textarea {:value @code
+                :on-change #(reset! code (.. % -target -value))
+                :rows 18
+                :style {:width "100%"
+                        :padding "12px"
+                        :font-family "monospace"
+                        :font-size "14px"
+                        :border "2px solid #D1D5DB"
+                        :border-radius "6px"
+                        :resize "vertical"
+                        :background-color "#FFFFFF"
+                        :color "#111827"}}]]
+   ;; Run button
+   [:button {:style {:width "100%"
+                     :padding "14px 24px"
+                     :background-color (cond
+                                         @running? "#9CA3AF"
+                                         (not @pandas-loaded?) "#9CA3AF"
+                                         :else "#10B981")
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :font-size "16px"
+                     :cursor (if (or @running? (not @pandas-loaded?))
+                               "not-allowed"
+                               "pointer")
+                     :margin-bottom "24px"}
+             :on-click run-analysis!
+             :disabled (or @running? (not @pandas-loaded?))}
+    (cond
+      @running? "Running Analysis..."
+      (not @pandas-loaded?) "Loading Pandas..."
+      :else "🐼 Run Analysis")]
+   ;; Output area
+   [:div {:style {:background-color "#FFFFFF"
+                  :border "2px solid #E5E7EB"
+                  :border-radius "8px"
+                  :padding "20px"
+                  :min-height "400px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "12px"
+                     :color "#374151"}}
+     "Analysis Results:"]
+    (if @output-html
+      [:div {:style {:overflow-x "auto"}}
+       ;; Add custom CSS for pandas tables
+       [:style "
+.dataframe {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 10px 0;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+.dataframe thead tr {
+  background-color: #F3F4F6;
+  text-align: left;
+  font-weight: 600;
+  color: #374151;
+}
+.dataframe th,
+.dataframe td {
+  padding: 12px 15px;
+  border-bottom: 1px solid #E5E7EB;
+}
+.dataframe tbody tr:hover {
+  background-color: #F9FAFB;
+}
+.dataframe tbody tr:last-of-type {
+  border-bottom: 2px solid #D1D5DB;
+}
+h4 {
+  color: #374151;
+  font-size: 16px;
+  font-weight: 600;
+  margin: 20px 0 10px 0;
+}"]
+       [:div {:dangerouslySetInnerHTML {:__html @output-html}}]]
+      [:div {:style {:padding "40px"
+                     :text-align "center"
+                     :color "#6B7280"
+                     :font-size "14px"}}
+       [:p {:style {:margin "0"}} @output-text]])]])
+
+;; Initialize pandas on mount - with retry logic
+(defonce init-done?
+  (do
+    (js/console.log "🚀 Pandas demo component mounted")
+    (letfn [(try-load []
+              (if (pyodide/ready?)
+                (do
+                  (js/console.log "✓ Pyodide ready, loading pandas...")
+                  (load-pandas!))
+                (do
+                  (js/console.log "⏳ Pyodide not ready, retrying in 500ms...")
+                  (js/setTimeout try-load 500))))]
+      (js/setTimeout try-load 100))
+    true))
+
+(rdom/render [main-component] (js/document.getElementById "pandas-demo"))

--- a/src/scittle/pyodide/pandas_viz_demo.cljs
+++ b/src/scittle/pyodide/pandas_viz_demo.cljs
@@ -1,0 +1,572 @@
+(ns scittle.pyodide.pandas-viz-demo
+  (:require
+   [reagent.core :as r]
+   [reagent.dom :as rdom]
+   [scittle.pyodide.pyodide-bridge :as pyodide]))
+
+;; ============================================================================
+;; Combined Pandas + Matplotlib Demo - Complete Data Science Workflows
+;; ============================================================================
+
+(defonce code (r/atom "# Sales Trend Analysis - Complete Workflow
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Sample sales data over 12 months
+data = {
+    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+              'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    'Sales': [45000, 52000, 48000, 65000, 70000, 68000,
+              75000, 82000, 79000, 88000, 95000, 102000],
+    'Expenses': [30000, 35000, 33000, 40000, 42000, 41000,
+                 45000, 48000, 46000, 52000, 55000, 58000]
+}
+
+df = pd.DataFrame(data)
+df['Profit'] = df['Sales'] - df['Expenses']
+df['Margin %'] = ((df['Profit'] / df['Sales']) * 100).round(1)
+
+# Summary Statistics
+print('<h3>📊 Monthly Performance Summary</h3>')
+summary = df[['Sales', 'Expenses', 'Profit']].describe().round(0)
+print(summary.to_html(border=0, classes='dataframe'))
+
+# Trend Visualization
+plt.figure(figsize=(12, 5))
+
+plt.subplot(1, 2, 1)
+plt.plot(df['Month'], df['Sales'], marker='o', linewidth=2,
+         label='Sales', color='#10B981', markersize=8)
+plt.plot(df['Month'], df['Expenses'], marker='s', linewidth=2,
+         label='Expenses', color='#EF4444', markersize=8)
+plt.plot(df['Month'], df['Profit'], marker='^', linewidth=2,
+         label='Profit', color='#3B82F6', markersize=8)
+plt.title('Sales Trend Analysis', fontsize=14, fontweight='bold')
+plt.xlabel('Month', fontsize=11)
+plt.ylabel('Amount ($)', fontsize=11)
+plt.legend(loc='upper left')
+plt.grid(True, alpha=0.3)
+plt.xticks(rotation=45)
+
+plt.subplot(1, 2, 2)
+plt.bar(df['Month'], df['Profit'], color='#10B981', alpha=0.7, edgecolor='white', linewidth=1.5)
+plt.title('Monthly Profit', fontsize=14, fontweight='bold')
+plt.xlabel('Month', fontsize=11)
+plt.ylabel('Profit ($)', fontsize=11)
+plt.grid(axis='y', alpha=0.3)
+plt.xticks(rotation=45)
+
+plt.tight_layout()"))
+
+(defonce output-html (r/atom nil))
+(defonce output-image (r/atom nil))
+(defonce output-text (r/atom "Click 'Run Workflow' to see the complete analysis"))
+(defonce running? (r/atom false))
+(defonce libs-loaded? (r/atom false))
+
+;; Workflow examples combining pandas and matplotlib
+(def workflow-examples
+  {:sales-trend "# Sales Trend Analysis - Complete Workflow
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Sample sales data over 12 months
+data = {
+    'Month': ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+              'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    'Sales': [45000, 52000, 48000, 65000, 70000, 68000,
+              75000, 82000, 79000, 88000, 95000, 102000],
+    'Expenses': [30000, 35000, 33000, 40000, 42000, 41000,
+                 45000, 48000, 46000, 52000, 55000, 58000]
+}
+
+df = pd.DataFrame(data)
+df['Profit'] = df['Sales'] - df['Expenses']
+df['Margin %'] = ((df['Profit'] / df['Sales']) * 100).round(1)
+
+# Summary Statistics
+print('<h3>📊 Monthly Performance Summary</h3>')
+summary = df[['Sales', 'Expenses', 'Profit']].describe().round(0)
+print(summary.to_html(border=0, classes='dataframe'))
+
+# Trend Visualization
+plt.figure(figsize=(12, 5))
+
+plt.subplot(1, 2, 1)
+plt.plot(df['Month'], df['Sales'], marker='o', linewidth=2,
+         label='Sales', color='#10B981', markersize=8)
+plt.plot(df['Month'], df['Expenses'], marker='s', linewidth=2,
+         label='Expenses', color='#EF4444', markersize=8)
+plt.plot(df['Month'], df['Profit'], marker='^', linewidth=2,
+         label='Profit', color='#3B82F6', markersize=8)
+plt.title('Sales Trend Analysis', fontsize=14, fontweight='bold')
+plt.xlabel('Month', fontsize=11)
+plt.ylabel('Amount ($)', fontsize=11)
+plt.legend(loc='upper left')
+plt.grid(True, alpha=0.3)
+plt.xticks(rotation=45)
+
+plt.subplot(1, 2, 2)
+plt.bar(df['Month'], df['Profit'], color='#10B981', alpha=0.7, edgecolor='white', linewidth=1.5)
+plt.title('Monthly Profit', fontsize=14, fontweight='bold')
+plt.xlabel('Month', fontsize=11)
+plt.ylabel('Profit ($)', fontsize=11)
+plt.grid(axis='y', alpha=0.3)
+plt.xticks(rotation=45)
+
+plt.tight_layout()"
+
+   :product-analysis "# Product Performance Analysis
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# Product sales data by category
+data = {
+    'Product': ['Laptop', 'Phone', 'Tablet', 'Watch', 'Headphones',
+                'Laptop', 'Phone', 'Tablet', 'Watch', 'Headphones',
+                'Laptop', 'Phone', 'Tablet', 'Watch', 'Headphones'],
+    'Quarter': ['Q1', 'Q1', 'Q1', 'Q1', 'Q1',
+                'Q2', 'Q2', 'Q2', 'Q2', 'Q2',
+                'Q3', 'Q3', 'Q3', 'Q3', 'Q3'],
+    'Units': [150, 280, 120, 95, 210,
+              180, 320, 140, 110, 245,
+              210, 350, 155, 125, 280],
+    'Revenue': [225000, 224000, 84000, 28500, 31500,
+                270000, 256000, 98000, 33000, 36750,
+                315000, 280000, 108500, 37500, 42000]
+}
+
+df = pd.DataFrame(data)
+df['Avg_Price'] = (df['Revenue'] / df['Units']).round(0)
+
+# Analysis by Product
+print('<h3>📦 Product Performance by Quarter</h3>')
+product_summary = df.groupby('Product').agg({
+    'Units': 'sum',
+    'Revenue': 'sum',
+    'Avg_Price': 'mean'
+}).round(0)
+product_summary['Revenue'] = product_summary['Revenue'].astype(int)
+print(product_summary.to_html(border=0, classes='dataframe'))
+
+# Visualizations
+plt.figure(figsize=(12, 5))
+
+plt.subplot(1, 2, 1)
+products = product_summary.index
+units = product_summary['Units']
+colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6']
+plt.bar(products, units, color=colors, alpha=0.8, edgecolor='white', linewidth=2)
+plt.title('Total Units Sold by Product', fontsize=14, fontweight='bold')
+plt.xlabel('Product', fontsize=11)
+plt.ylabel('Units Sold', fontsize=11)
+plt.xticks(rotation=45, ha='right')
+plt.grid(axis='y', alpha=0.3)
+
+plt.subplot(1, 2, 2)
+revenue = product_summary['Revenue']
+plt.barh(products, revenue, color=colors, alpha=0.8, edgecolor='white', linewidth=2)
+plt.title('Revenue by Product', fontsize=14, fontweight='bold')
+plt.xlabel('Revenue ($)', fontsize=11)
+plt.ylabel('Product', fontsize=11)
+plt.grid(axis='x', alpha=0.3)
+
+plt.tight_layout()"
+
+   :regional-breakdown "# Regional Sales Breakdown with Multiple Charts
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Regional sales data
+data = {
+    'Region': ['North', 'South', 'East', 'West'] * 3,
+    'Quarter': ['Q1']*4 + ['Q2']*4 + ['Q3']*4,
+    'Sales': [450000, 380000, 520000, 490000,
+              480000, 410000, 560000, 520000,
+              510000, 435000, 595000, 555000],
+    'Customers': [1200, 950, 1400, 1300,
+                  1280, 1020, 1480, 1350,
+                  1350, 1080, 1560, 1420]
+}
+
+df = pd.DataFrame(data)
+df['Avg_Sale'] = (df['Sales'] / df['Customers']).round(2)
+
+# Pivot table for analysis
+print('<h3>🗺️ Regional Performance Matrix</h3>')
+pivot = df.pivot_table(values='Sales', index='Region', columns='Quarter', aggfunc='sum')
+pivot['Total'] = pivot.sum(axis=1)
+print(pivot.to_html(border=0, classes='dataframe'))
+
+# Multiple visualizations
+fig = plt.figure(figsize=(12, 8))
+
+# Regional comparison
+ax1 = plt.subplot(2, 2, 1)
+regions = df.groupby('Region')['Sales'].sum()
+colors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444']
+plt.bar(regions.index, regions.values, color=colors, alpha=0.8, edgecolor='white', linewidth=2)
+plt.title('Total Sales by Region', fontsize=12, fontweight='bold')
+plt.ylabel('Sales ($)', fontsize=10)
+plt.xticks(rotation=45)
+plt.grid(axis='y', alpha=0.3)
+
+# Quarterly trend
+ax2 = plt.subplot(2, 2, 2)
+for region in ['North', 'South', 'East', 'West']:
+    region_data = df[df['Region'] == region]
+    plt.plot(region_data['Quarter'], region_data['Sales'],
+             marker='o', linewidth=2, label=region, markersize=8)
+plt.title('Quarterly Sales Trend', fontsize=12, fontweight='bold')
+plt.ylabel('Sales ($)', fontsize=10)
+plt.legend()
+plt.grid(True, alpha=0.3)
+
+# Customer growth
+ax3 = plt.subplot(2, 2, 3)
+customer_trend = df.groupby('Quarter')['Customers'].sum()
+plt.plot(customer_trend.index, customer_trend.values,
+         marker='o', linewidth=3, color='#8B5CF6', markersize=10)
+plt.title('Total Customers by Quarter', fontsize=12, fontweight='bold')
+plt.ylabel('Customers', fontsize=10)
+plt.grid(True, alpha=0.3)
+
+# Average sale value
+ax4 = plt.subplot(2, 2, 4)
+avg_sales = df.groupby('Region')['Avg_Sale'].mean()
+plt.barh(avg_sales.index, avg_sales.values, color=colors, alpha=0.8, edgecolor='white', linewidth=2)
+plt.title('Avg Sale per Customer', fontsize=12, fontweight='bold')
+plt.xlabel('Average ($)', fontsize=10)
+plt.grid(axis='x', alpha=0.3)
+
+plt.tight_layout()"
+
+   :time-series "# Time Series Analysis with Moving Averages
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Daily sales data
+np.random.seed(42)
+dates = pd.date_range('2024-01-01', periods=90, freq='D')
+trend = np.linspace(1000, 1500, 90)
+seasonal = 200 * np.sin(np.linspace(0, 4*np.pi, 90))
+noise = np.random.normal(0, 50, 90)
+sales = trend + seasonal + noise
+
+df = pd.DataFrame({
+    'Date': dates,
+    'Sales': sales
+})
+
+# Calculate moving averages
+df['MA_7'] = df['Sales'].rolling(window=7).mean()
+df['MA_30'] = df['Sales'].rolling(window=30).mean()
+
+# Summary statistics
+print('<h3>📅 Time Series Summary (90 Days)</h3>')
+stats = pd.DataFrame({
+    'Metric': ['Total Sales', 'Average Daily', 'Max Daily', 'Min Daily', 'Std Dev'],
+    'Value': [
+        f\"${df['Sales'].sum():,.0f}\",
+        f\"${df['Sales'].mean():,.0f}\",
+        f\"${df['Sales'].max():,.0f}\",
+        f\"${df['Sales'].min():,.0f}\",
+        f\"${df['Sales'].std():,.0f}\"
+    ]
+})
+print(stats.to_html(index=False, border=0, classes='dataframe'))
+
+# Visualization
+plt.figure(figsize=(12, 6))
+
+plt.subplot(2, 1, 1)
+plt.plot(df['Date'], df['Sales'], label='Daily Sales',
+         alpha=0.5, color='#9CA3AF', linewidth=1)
+plt.plot(df['Date'], df['MA_7'], label='7-Day MA',
+         color='#3B82F6', linewidth=2)
+plt.plot(df['Date'], df['MA_30'], label='30-Day MA',
+         color='#EF4444', linewidth=2)
+plt.title('Sales with Moving Averages', fontsize=14, fontweight='bold')
+plt.ylabel('Sales ($)', fontsize=11)
+plt.legend()
+plt.grid(True, alpha=0.3)
+
+plt.subplot(2, 1, 2)
+monthly = df.set_index('Date').resample('M')['Sales'].sum()
+plt.bar(range(len(monthly)), monthly.values,
+        color='#10B981', alpha=0.8, edgecolor='white', linewidth=2)
+plt.title('Monthly Sales Totals', fontsize=14, fontweight='bold')
+plt.xlabel('Month', fontsize=11)
+plt.ylabel('Total Sales ($)', fontsize=11)
+plt.xticks(range(len(monthly)), ['Jan', 'Feb', 'Mar'])
+plt.grid(axis='y', alpha=0.3)
+
+plt.tight_layout()"})
+
+(defn load-libraries!
+  []
+  (js/console.log "🔍 Starting pandas + matplotlib load check...")
+  (when (pyodide/ready?)
+    (js/console.log "✓ Pyodide is ready, loading libraries...")
+    (reset! output-text "Loading pandas and matplotlib (this may take 30-60 seconds)...")
+    (-> (pyodide/load-packages "matplotlib")
+        (.then (fn [_]
+                 (js/console.log "✓ Matplotlib loaded")
+                 (pyodide/load-packages "pandas")))
+        (.then (fn [_]
+                 (js/console.log "✓ Pandas loaded")
+                 (reset! libs-loaded? true)
+                 (reset! output-text "Libraries ready! Click 'Run Workflow' to see analysis")))
+        (.catch (fn [err]
+                  (js/console.error "✗ Failed to load libraries:" err)
+                  (reset! output-text (str "Error loading libraries: " (.-message err))))))))
+
+(defn run-workflow!
+  []
+  (when @libs-loaded?
+    (reset! running? true)
+    (reset! output-text "Running complete workflow...")
+    (reset! output-html nil)
+    (reset! output-image nil)
+    ;; First, capture the HTML output (tables)
+    (-> (pyodide/run-python-with-output @code)
+        (.then (fn [html-result]
+                 (reset! output-html (str html-result))
+                 ;; Then, capture the plot
+                 (pyodide/run-python-with-plot @code)))
+        (.then (fn [plot-result]
+                 (reset! output-image plot-result)
+                 (reset! output-text "")
+                 (reset! running? false)))
+        (.catch (fn [err]
+                  (reset! output-text (str "Error:\n" (.-message err)))
+                  (reset! output-html nil)
+                  (reset! output-image nil)
+                  (reset! running? false))))))
+
+(defn load-example!
+  [example-key]
+  (reset! code (get workflow-examples example-key))
+  (reset! output-html nil)
+  (reset! output-image nil)
+  (reset! output-text "Example loaded. Click 'Run Workflow' to see the complete analysis"))
+
+(defn main-component
+  []
+  [:div {:style {:max-width "1200px"
+                 :margin "0 auto"
+                 :padding "24px"}}
+   [:h2 {:style {:font-size "28px"
+                 :font-weight "bold"
+                 :margin-bottom "8px"
+                 :color "#111827"}}
+    "🎯 Complete Data Science Workflows"]
+   [:p {:style {:color "#6B7280"
+                :margin-bottom "24px"
+                :font-size "16px"}}
+    "Combine Pandas data analysis with Matplotlib visualizations for complete end-to-end workflows!"]
+   ;; Info banner
+   [:div {:style {:background-color (if @libs-loaded? "#D1FAE5" "#DBEAFE")
+                  :border-left (str "4px solid " (if @libs-loaded? "#10B981" "#3B82F6"))
+                  :padding "16px"
+                  :margin-bottom "24px"
+                  :border-radius "4px"}}
+    [:p {:style {:font-size "14px"
+                 :color (if @libs-loaded? "#065F46" "#1E40AF")
+                 :margin "0"}}
+     (if @libs-loaded?
+       "✓ Pandas & Matplotlib are loaded and ready!"
+       "Loading pandas and matplotlib... This may take 30-60 seconds on first load.")]]
+   ;; Workflow examples
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Complete Workflow Examples:"]
+    [:div {:style {:display "flex"
+                   :gap "8px"
+                   :flex-wrap "wrap"}}
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :sales-trend)}
+      "📈 Sales Trend"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :product-analysis)}
+      "📦 Product Analysis"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :regional-breakdown)}
+      "🗺️ Regional Analysis"]
+     [:button {:style {:padding "8px 16px"
+                       :background-color "#F3F4F6"
+                       :color "#374151"
+                       :border "1px solid #D1D5DB"
+                       :border-radius "6px"
+                       :font-size "14px"
+                       :cursor "pointer"
+                       :font-weight "500"}
+               :on-click #(load-example! :time-series)}
+      "📅 Time Series"]]]
+   ;; Code editor
+   [:div {:style {:margin-bottom "16px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "8px"
+                     :color "#374151"}}
+     "Python Code (Pandas + Matplotlib):"]
+    [:textarea {:value @code
+                :on-change #(reset! code (.. % -target -value))
+                :rows 20
+                :style {:width "100%"
+                        :padding "12px"
+                        :font-family "monospace"
+                        :font-size "13px"
+                        :border "2px solid #D1D5DB"
+                        :border-radius "6px"
+                        :resize "vertical"
+                        :background-color "#FFFFFF"
+                        :color "#111827"
+                        :line-height "1.5"}}]]
+   ;; Run button
+   [:button {:style {:width "100%"
+                     :padding "14px 24px"
+                     :background-color (cond
+                                         @running? "#9CA3AF"
+                                         (not @libs-loaded?) "#9CA3AF"
+                                         :else "#8B5CF6")
+                     :color "#FFFFFF"
+                     :border "none"
+                     :border-radius "6px"
+                     :font-weight "600"
+                     :font-size "16px"
+                     :cursor (if (or @running? (not @libs-loaded?))
+                               "not-allowed"
+                               "pointer")
+                     :margin-bottom "24px"}
+             :on-click run-workflow!
+             :disabled (or @running? (not @libs-loaded?))}
+    (cond
+      @running? "⏳ Running Workflow..."
+      (not @libs-loaded?) "Loading Libraries..."
+      :else "🎯 Run Complete Workflow")]
+   ;; Output area
+   [:div {:style {:background-color "#FFFFFF"
+                  :border "2px solid #E5E7EB"
+                  :border-radius "8px"
+                  :padding "20px"
+                  :min-height "500px"}}
+    [:label {:style {:display "block"
+                     :font-size "14px"
+                     :font-weight "600"
+                     :margin-bottom "12px"
+                     :color "#374151"}}
+     "Analysis Results:"]
+    (when (or @output-html @output-image)
+      [:div
+       ;; Tables section
+       (when @output-html
+         [:div {:style {:margin-bottom "24px"}}
+          [:style "
+.dataframe {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 10px 0;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+.dataframe thead tr {
+  background-color: #F3F4F6;
+  text-align: left;
+  font-weight: 600;
+  color: #374151;
+}
+.dataframe th,
+.dataframe td {
+  padding: 12px 15px;
+  border-bottom: 1px solid #E5E7EB;
+  text-align: left;
+}
+.dataframe tbody tr:hover {
+  background-color: #F9FAFB;
+}
+.dataframe tbody tr:last-of-type {
+  border-bottom: 2px solid #D1D5DB;
+}
+h3 {
+  color: #374151;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 24px 0 12px 0;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #E5E7EB;
+}"]
+          [:div {:dangerouslySetInnerHTML {:__html @output-html}}]])
+       ;; Visualization section
+       (when @output-image
+         [:div {:style {:margin-top "24px"
+                        :padding-top "24px"
+                        :border-top "2px solid #E5E7EB"}}
+          [:h3 {:style {:color "#374151"
+                        :font-size "18px"
+                        :font-weight "600"
+                        :margin-bottom "16px"}}
+           "📊 Visualizations"]
+          [:div {:style {:text-align "center"
+                         :background-color "#F9FAFB"
+                         :padding "20px"
+                         :border-radius "8px"}}
+           [:img {:src (str "data:image/png;base64," @output-image)
+                  :alt "Data Visualization"
+                  :style {:max-width "100%"
+                          :height "auto"
+                          :border-radius "4px"
+                          :box-shadow "0 4px 12px rgba(0,0,0,0.1)"}}]]])])
+    (when (and (not @output-html) (not @output-image))
+      [:div {:style {:padding "60px 40px"
+                     :text-align "center"
+                     :color "#6B7280"
+                     :font-size "14px"}}
+       [:p {:style {:margin "0"}} @output-text]])]])
+
+;; Initialize libraries on mount - with retry logic
+(defonce init-done?
+  (do
+    (js/console.log "🚀 Pandas + Matplotlib workflow demo mounted")
+    (letfn [(try-load []
+              (if (pyodide/ready?)
+                (do
+                  (js/console.log "✓ Pyodide ready, loading libraries...")
+                  (load-libraries!))
+                (do
+                  (js/console.log "⏳ Pyodide not ready, retrying in 500ms...")
+                  (js/setTimeout try-load 500))))]
+      (js/setTimeout try-load 100))
+    true))
+
+(rdom/render [main-component] (js/document.getElementById "pandas-viz-demo"))

--- a/src/scittle/pyodide/pyodide_bridge.cljs
+++ b/src/scittle/pyodide/pyodide_bridge.cljs
@@ -1,0 +1,180 @@
+(ns scittle.pyodide.pyodide-bridge
+  (:require [reagent.core :as r]))
+
+;; ============================================================================
+;; Shared Pyodide Bridge for Scittle Demos
+;; This provides a single source of truth for Pyodide state across all demos
+;; ============================================================================
+
+;; Global state - shared across all demos
+(defonce pyodide-instance (r/atom nil))
+
+(defonce loading? (r/atom false))
+
+(defonce error (r/atom nil))
+
+;; ============================================================================
+;; Core Pyodide Functions
+;; ============================================================================
+
+(defn init!
+  "Initialize Pyodide if not already initialized. Safe to call multiple times.
+   Returns a promise that resolves when Pyodide is ready."
+  []
+  (cond
+    ;; Already loaded - return resolved promise with instance
+    @pyodide-instance
+    (do
+      (js/console.log "Pyodide already initialized")
+      (js/Promise.resolve @pyodide-instance))
+    ;; Currently loading - return existing promise (will resolve when done)
+    @loading?
+    (do
+      (js/console.log "Pyodide is already loading, please wait...")
+      (js/Promise.resolve nil))
+    ;; Not started - start loading
+    :else
+    (do
+      (js/console.log "Starting Pyodide initialization...")
+      (reset! loading? true)
+      (reset! error nil)
+      (-> (js/loadPyodide
+           #js {:indexURL "https://cdn.jsdelivr.net/pyodide/v0.28.3/full/"
+                :fullStdLib false})
+          (.then (fn [pyodide]
+                   (js/console.log "✓ Pyodide loaded successfully")
+                   (reset! pyodide-instance pyodide)
+                   (reset! loading? false)
+                   pyodide))
+          (.catch (fn [err]
+                    (js/console.error "✗ Failed to load Pyodide:" err)
+                    (reset! error (.-message err))
+                    (reset! loading? false)
+                    (js/Promise.reject err)))))))
+
+(defn get-instance
+  "Get the current Pyodide instance (may be nil if not initialized)"
+  []
+  @pyodide-instance)
+
+(defn ready?
+  "Check if Pyodide is ready to use"
+  []
+  (some? @pyodide-instance))
+
+(defn is-loading?
+  "Check if Pyodide is currently loading"
+  []
+  @loading?)
+
+(defn get-error
+  "Get the current error message (if any)"
+  []
+  @error)
+
+(defn status
+  "Get current status as keyword: :not-started, :loading, :ready, or :error"
+  []
+  (cond
+    @error :error
+    @pyodide-instance :ready
+    @loading? :loading
+    :else :not-started))
+
+;; ============================================================================
+;; Convenience Functions
+;; ============================================================================
+
+(defn run-python
+  "Execute Python code. Returns a promise resolving to the result.
+   Automatically waits for Pyodide to be ready."
+  [code]
+  (if-let [pyodide @pyodide-instance]
+    (.runPythonAsync pyodide code)
+    (js/Promise.reject (js/Error. "Pyodide not initialized"))))
+
+(defn load-packages
+  "Load Python packages. Returns a promise.
+   Example: (load-packages [\"matplotlib\" \"pandas\"])"
+  [package-names]
+  (if-let [pyodide @pyodide-instance]
+    (if (sequential? package-names)
+      (js/Promise.all
+       (clj->js (map #(.loadPackage pyodide %) package-names)))
+      (.loadPackage pyodide package-names))
+    (js/Promise.reject (js/Error. "Pyodide not initialized"))))
+
+(defn set-global
+  "Set a global variable in Python namespace"
+  [var-name value]
+  (when-let [pyodide @pyodide-instance]
+    (aset (.-globals pyodide) var-name value)))
+
+(defn get-global
+  "Get a global variable from Python namespace"
+  [var-name]
+  (when-let [pyodide @pyodide-instance]
+    (aget (.-globals pyodide) var-name)))
+
+(defn run-python-with-plot
+  "Execute Python code that generates a matplotlib plot.
+   Returns a promise resolving to a base64-encoded PNG image.
+   The Python code should create a matplotlib figure."
+  [code]
+  (if-let [pyodide @pyodide-instance]
+    (let [plot-code (str "
+import io
+import base64
+import matplotlib
+matplotlib.use('Agg')  # Use non-interactive backend
+import matplotlib.pyplot as plt
+
+# Clear any previous plots
+plt.clf()
+plt.close('all')
+
+# User's plotting code
+" code "
+
+# Capture the plot
+buf = io.BytesIO()
+plt.savefig(buf, format='png', bbox_inches='tight', dpi=100)
+buf.seek(0)
+img_base64 = base64.b64encode(buf.read()).decode('utf-8')
+buf.close()
+plt.close('all')
+
+# Return the base64 string
+img_base64
+")]
+      (.runPythonAsync pyodide plot-code))
+    (js/Promise.reject (js/Error. "Pyodide not initialized"))))
+
+(defn run-python-with-output
+  "Execute Python code and capture stdout (print statements).
+   Returns a promise resolving to the captured output as a string.
+   This is useful for pandas DataFrames that use print(df.to_html())."
+  [code]
+  (if-let [pyodide @pyodide-instance]
+    (let [capture-code (str "
+import sys
+import io
+
+# Capture stdout
+captured_output = io.StringIO()
+sys.stdout = captured_output
+
+# User's code
+" code "
+
+# Get the captured output
+output = captured_output.getvalue()
+
+# Restore stdout
+sys.stdout = sys.__stdout__
+
+# Return the captured output
+output
+")]
+      (.runPythonAsync pyodide capture-code))
+    (js/Promise.reject (js/Error. "Pyodide not initialized"))))

--- a/src/scittle/pyodide/pyodide_integration.clj
+++ b/src/scittle/pyodide/pyodide_integration.clj
@@ -1,0 +1,242 @@
+^:kindly/hide-code
+^{:kindly/options {:html/deps [:scittle :reagent]}
+  :clay {:title "Python + ClojureScript: Pyodide Integration with Scittle"
+         :quarto {:author [:burinc]
+                  :description "Run Python code directly in the browser using Pyodide with Scittle and ClojureScript"
+                  :type :post
+                  :date "2025-11-05"
+                  :category :libs
+                  :tags [:scittle
+                         :clojurescript
+                         :python
+                         :pyodide
+                         :data-science
+                         :no-build]
+                  :keywords [:pyodide
+                             :python
+                             :scittle
+                             :browser
+                             :data-science
+                             :matplotlib
+                             :pandas]}}}
+
+(ns scittle.pyodide.pyodide-integration
+  (:require [scicloj.kindly.v4.kind :as kind]))
+
+;; # Python + ClojureScript: Pyodide Integration with Scittle
+
+;; ## About This Project
+
+;; This is the **second installment** in my exploration of browser-native development with Scittle. In my first article, [Building Browser-Native Presentations with Scittle](https://clojurecivitas.github.io/scittle/presentations/browser_native_slides.html), I shared how I've been using Scittle to create interactive presentations for local meetups, spreading the love of Clojure and ClojureScript by showing how accessible it can be without build tools. That project came from a desire to make ClojureScript more approachable and, honestly, more fun.
+
+;; After presenting those interactive ClojureScript demos to the community, I kept thinking: "How do I reach Python developers? How do I show them what ClojureScript brings to the table?" The Python community has incredible data science tools like Pandas and Matplotlib, but they're typically tied to server-side execution. I wanted to bridge these two worlds in a way that would be both impressive and fun - showing Python developers that ClojureScript isn't just another JavaScript framework, while giving Clojure developers a way to leverage Python's rich ecosystem.
+
+;; This project is my answer - and my way of keeping the joy of programming alive. By combining Pyodide (Python compiled to WebAssembly) with Scittle's zero-build approach, I can demonstrate something pretty cool: you can write Python for data science, wrap it in elegant ClojureScript UIs, and deploy everything as a single HTML file. No Python backend, no Node.js build pipeline, no complexity. Just fun, interactive data science in the browser.
+
+;; Whether you're a Python developer curious about ClojureScript, a Clojure developer wanting to leverage Python libraries, or someone like me who just loves exploring what's possible when you remove unnecessary complexity, I hope these examples inspire you. The source code is fully available for you to learn from, adapt, and build upon. Let's keep programming fun and accessible.
+
+;; Now let's explore how ClojureScript and Python can work together, beautifully.
+
+;; ## The Vision
+
+;; Imagine being able to:
+;; - Write Python data science code in your browser
+;; - Visualize data with matplotlib without any backend
+;; - Process data with pandas entirely client-side
+;; - All while orchestrating everything with ClojureScript
+;; - **Without any build tools or server**
+
+;; This isn't science fiction. It's **Pyodide + Scittle**.
+
+;; ## What is Pyodide?
+
+;; [Pyodide](https://pyodide.org/) is a Python distribution compiled to WebAssembly that runs entirely in the browser. It includes:
+;; - Full Python 3.11 interpreter
+;; - NumPy, Pandas, Matplotlib, SciPy
+;; - 100+ scientific packages
+;; - Full file system (in-memory)
+;; - ~8MB download (compressed)
+
+;; **Think of it as Python's REPL, but in your browser.**
+
+;; ## Simple Example: Hello Python
+
+;; Let's start with the simplest possible example - loading Pyodide and running Python code.
+
+;; The demo below shows a basic Python REPL where you can:
+;; - Load Pyodide from CDN
+;; - Execute Python expressions
+;; - See results instantly
+;; - Handle errors gracefully
+
+;; ### Try It Live
+
+(kind/hiccup
+ [:div#hello-python-demo {:style {:min-height "400px"}}
+  ;; Load Pyodide CDN first - this provides js/loadPyodide
+  [:script {:src "https://cdn.jsdelivr.net/pyodide/v0.28.3/full/pyodide.js"}]
+  ;; Then load the shared Pyodide bridge
+  [:script {:type "application/x-scittle"
+            :src "pyodide_bridge.cljs"}]
+  ;; Finally load the demo
+  [:script {:type "application/x-scittle"
+            :src "hello_python.cljs"}]])
+
+;; ## How It Works
+
+;; The integration uses a **shared bridge** pattern:
+
+;; 1. **pyodide_bridge.cljs** - Manages the Pyodide instance and state
+;; 2. **hello_python.cljs** - Uses the bridge to run Python code
+;; 3. The bridge is loaded first, then the demo can use its functions
+
+;; This prevents multiple Pyodide instances from conflicting!
+
+;; ## Interactive Code Editor
+
+;; Now let's build something more powerful - an interactive code editor where you can write and run your own Python code!
+
+;; ### Key Features
+
+;; - Live code editing with syntax highlighting
+;; - Run button to execute code
+;; - Output display for results and errors
+;; - Pre-filled with example code
+
+;; ### Try It Live
+
+(kind/hiccup
+ [:div#code-editor-demo {:style {:min-height "500px"}}
+  ;; Load the code editor (Pyodide is already loaded from first demo)
+  [:script {:type "application/x-scittle"
+            :src "code_editor.cljs"}]])
+
+;; ## Data Visualization with Matplotlib
+
+;; Now for the exciting part - creating beautiful data visualizations with Python's matplotlib library!
+
+;; The demo below captures matplotlib plots as base64 PNG images and displays them inline. This technique:
+;; - Uses matplotlib's non-interactive 'Agg' backend
+;; - Captures plots as PNG data
+;; - Displays high-quality visualizations
+;; - Includes pre-loaded examples (line, bar, scatter, pie charts)
+
+;; ### Try It Live
+
+(kind/hiccup
+ [:div#data-visualization-demo {:style {:min-height "700px"}}
+  ;; Load the data visualization demo (uses already-loaded Pyodide)
+  [:script {:type "application/x-scittle"
+            :src "data_visualization.cljs"}]])
+
+;; ## DataFrame Analysis with Pandas
+
+;; Beyond visualization, Pyodide includes the full **Pandas** library for powerful data analysis and manipulation!
+
+;; ### Why Pandas in the Browser?
+
+;; Pandas is the standard tool for data analysis in Python. With Pyodide, you can:
+;; - Load and manipulate tabular data
+;; - Perform statistical analysis
+;; - Filter, group, and transform datasets
+;; - All without a backend server!
+
+;; The demo includes examples of:
+;; - **Creating DataFrames** - Build tables from Python dictionaries
+;; - **Statistical Analysis** - Summary statistics and correlations
+;; - **Data Transformations** - Filter, calculate, sort, and rank
+;; - **GroupBy Operations** - Aggregate data by categories
+
+;; ### Try It Live
+
+(kind/hiccup
+ [:div#pandas-demo {:style {:min-height "700px"}}
+  ;; Load the pandas demo (uses already-loaded Pyodide)
+  [:script {:type "application/x-scittle"
+            :src "pandas_demo.cljs"}]])
+
+;; ## Complete Data Science Workflows
+
+;; Now for the **most powerful** demonstration - combining Pandas and Matplotlib for complete end-to-end data science workflows!
+
+;; ### Why Combine Them?
+
+;; In real-world data science, you rarely use just one tool. You:
+;; 1. **Load and clean data** with Pandas
+;; 2. **Analyze and transform** to extract insights
+;; 3. **Visualize results** with Matplotlib
+;; 4. **Present findings** with tables and charts together
+
+;; ### Complete Workflow Examples
+
+;; **Sales Trend Analysis:**
+;; - Load monthly sales data into DataFrame
+;; - Calculate profit and margins
+;; - Generate statistical summary
+;; - Create trend lines and bar charts
+;; - Display both tables and visualizations
+
+;; **Product Performance:**
+;; - Analyze product sales across quarters
+;; - Aggregate by product category
+;; - Compare units sold and revenue
+;; - Show horizontal and vertical bar charts
+
+;; **Regional Breakdown:**
+;; - Multi-dimensional analysis by region and quarter
+;; - Create pivot tables
+;; - Generate 4 different chart types
+;; - Display comprehensive dashboard
+
+;; **Time Series Analysis:**
+;; - 90 days of daily sales data
+;; - Calculate 7-day and 30-day moving averages
+;; - Aggregate to monthly totals
+;; - Visualize trends and patterns
+
+;; ### Key Features
+
+;; - **Side-by-side results** - See both tables and charts
+;; - **Multiple visualizations** - Up to 4 charts per workflow
+;; - **Real analysis** - Statistical summaries, aggregations, transformations
+;; - **Complete code** - Fully editable Python workflows
+
+;; ### Try It Live
+
+(kind/hiccup
+ [:div#pandas-viz-demo {:style {:min-height "800px"}}
+  ;; Load the combined pandas + matplotlib workflow demo
+  [:script {:type "application/x-scittle"
+            :src "pandas_viz_demo.cljs"}]])
+
+;; ## What's Possible?
+
+;; With Pyodide + Scittle, you can:
+
+;; - 📊 **Data Visualization** - Create interactive charts and plots with matplotlib
+;; - 🐍 **Python REPL** - Run any Python code in the browser
+;; - 🧮 **Scientific Computing** - Use NumPy, SciPy for calculations
+;; - 🐼 **Data Analysis** - Process and analyze data with Pandas DataFrames
+;; - 📈 **Statistical Analysis** - Descriptive statistics, correlations, grouping
+;; - 🎯 **Complete Workflows** - Combine pandas analysis with matplotlib visualizations
+;; - 🎨 **Custom UIs** - Wrap Python functionality in beautiful ClojureScript UIs
+
+;; ## Next Steps
+
+;; Explore more advanced features:
+;; - Advanced pandas operations (joins, pivots, time series)
+;; - Interactive data exploration with dynamic filtering
+;; - Machine learning with scikit-learn
+;; - Custom Python packages and modules
+
+;; ---
+
+;; ## Acknowledgments
+
+;; A special thanks to [Timothy Pratley](https://github.com/timothypratley) for creating ClojureCivitas - a welcoming space where the Clojure community can come together to share knowledge, experiences, and our collective love for the Clojure/ClojureScript ecosystem. Projects like this thrive when we have platforms to showcase what's possible and inspire others to explore.
+
+;; ---
+
+;; **Questions?** Find me on Clojurians Slack (@agilecreativity)
+;;
+;; *Built with Scittle, Pyodide, Reagent, and ❤️*


### PR DESCRIPTION
## Add Pyodide + Scittle Integration: Browser-Native Python Data Science

Introduces complete Pyodide integration with Scittle, enabling Python data science workflows entirely in the browser without build tools or servers.

### What's Added

- **`pyodide_bridge.cljs`** - Shared Pyodide instance manager with reactive state
- **5 progressive demos**: Hello Python → Code Editor → Matplotlib → Pandas → Complete Workflows
- **Full documentation** (`pyodide_integration.clj`) with narrative and embedded live demos

### Key Features

- 🐍 Run Python 3.11 + NumPy/Pandas/Matplotlib in browser
- 📊 Create data visualizations (charts, plots) client-side
- 🐼 Perform DataFrame analysis without backend
- 🎨 Beautiful ClojureScript UIs wrapping Python functionality
- ⚡ Zero-build deployment - pure Scittle, single HTML file

### Technical Highlights

- Shared bridge pattern prevents multiple Pyodide instances
- Reagent atoms for reactive state management
- Base64 PNG capture for matplotlib plots
- HTML table rendering from pandas DataFrames
- Progressive complexity from simple to complete workflows

**Purpose**: Bridge Python and ClojureScript communities by showing how to leverage Python's data science ecosystem with ClojureScript's elegant UI capabilities, all running browser-native.

**Branch**: `scittle-with-python-pyodide`