### PR TITLE
feat: Add comprehensive dark mode support to all Pyodide demos

### DIFF
--- a/src/scittle/pyodide/code_editor.cljs
+++ b/src/scittle/pyodide/code_editor.cljs
@@ -8,6 +8,21 @@
 ;; Interactive Python Code Editor
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 (defonce code (r/atom "# Try some Python code!\nimport math\n\nradius = 5\narea = math.pi * radius ** 2\nprint(f'Circle area: {area:.2f}')"))
 
 (defonce output (r/atom ""))
@@ -40,14 +55,16 @@
                  :padding "24px"}}
    [:h2 {:style {:font-size "24px"
                  :font-weight "bold"
-                 :margin-bottom "16px"}}
+                 :margin-bottom "16px"
+                 :color (get-color "#111827" "#F3F4F6")}}
     "Python Code Editor 💻"]
 
-   [:div {:style {:background-color "#FEF3C7"
-                  :border-left "4px solid #F59E0B"
+   [:div {:style {:background-color (get-color "#FEF3C7" "#78350F")
+                  :border-left (str "4px solid " (get-color "#F59E0B" "#FCD34D"))
                   :padding "16px"
                   :margin-bottom "24px"}}
-    [:p {:style {:font-size "14px" :color "#374151"}}
+    [:p {:style {:font-size "14px"
+                 :color (get-color "#374151" "#FDE68A")}}
      "Write Python code below and click Run to execute it in your browser!"]]
 
    ;; Code editor
@@ -55,7 +72,8 @@
     [:label {:style {:display "block"
                      :font-size "14px"
                      :font-weight "600"
-                     :margin-bottom "8px"}}
+                     :margin-bottom "8px"
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Python Code:"]
     [:textarea {:value @code
                 :on-change #(reset! code (.. % -target -value))
@@ -64,14 +82,18 @@
                         :padding "12px"
                         :font-family "monospace"
                         :font-size "14px"
-                        :border "2px solid #D1D5DB"
+                        :background-color (get-color "#FFFFFF" "#1F2937")
+                        :color (get-color "#111827" "#F3F4F6")
+                        :border (str "2px solid " (get-color "#D1D5DB" "#4B5563"))
                         :border-radius "6px"
                         :resize "vertical"}}]]
 
    ;; Run button
    [:button {:style {:width "100%"
                      :padding "12px 24px"
-                     :background-color (if @running? "#9CA3AF" "#10B981")
+                     :background-color (if @running?
+                                         (get-color "#9CA3AF" "#6B7280")
+                                         (get-color "#10B981" "#059669"))
                      :color "#FFFFFF"
                      :border "none"
                      :border-radius "6px"
@@ -91,13 +113,14 @@
     [:label {:style {:display "block"
                      :font-size "14px"
                      :font-weight "600"
-                     :margin-bottom "8px"}}
+                     :margin-bottom "8px"
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Output:"]
-    [:pre {:style {:background-color "#F9FAFB"
-                   :color "#1F2937"
+    [:pre {:style {:background-color (get-color "#F9FAFB" "#1F2937")
+                   :color (get-color "#1F2937" "#F3F4F6")
                    :padding "16px"
                    :border-radius "6px"
-                   :border "2px solid #E5E7EB"
+                   :border (str "2px solid " (get-color "#E5E7EB" "#4B5563"))
                    :font-family "monospace"
                    :font-size "14px"
                    :min-height "120px"

--- a/src/scittle/pyodide/code_executor.cljs
+++ b/src/scittle/pyodide/code_executor.cljs
@@ -9,6 +9,21 @@
 ;; Uses shared pyodide-bridge for Pyodide state
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 ;; Local state - only UI/output state, Pyodide state is in bridge
 (defonce code (r/atom "# Write your Python code here\nprint('Hello, World!')\n\n# Try some calculations\nresult = 2 + 2\nprint(f'2 + 2 = {result}')"))
 
@@ -134,7 +149,10 @@ sys.stderr = _output_capture
        :on-change #(reset! code (.. % -target -value))
        :disabled (not= status :ready)
        :placeholder "Write your Python code here..."
-       :style {:background-color (if (= status :ready) "#ffffff" "#f5f5f5")
+       :style {:background-color (if (= status :ready)
+                                   (get-color "#ffffff" "#1F2937")
+                                   (get-color "#f5f5f5" "#374151"))
+               :color (get-color "#111827" "#F3F4F6")
                :resize "vertical"}}]]))
 
 (defn output-display

--- a/src/scittle/pyodide/data_visualization.cljs
+++ b/src/scittle/pyodide/data_visualization.cljs
@@ -4,6 +4,21 @@
             [scittle.pyodide.pyodide-bridge :as pyodide]))
 
 ;; ============================================================================
+;; Dark Mode Helpers
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
+;; ============================================================================
 ;; Matplotlib Data Visualization Demo
 ;; ============================================================================
 
@@ -134,20 +149,24 @@ plt.axis('equal')"})
    [:h2 {:style {:font-size "28px"
                  :font-weight "bold"
                  :margin-bottom "8px"
-                 :color "#111827"}}
+                 :color (get-color "#111827" "#F3F4F6")}}
     "📊 Data Visualization with Matplotlib"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "24px"
                 :font-size "16px"}}
     "Create beautiful charts and visualizations using Python's matplotlib library, running entirely in your browser!"]
    ;; Info banner
-   [:div {:style {:background-color (if @matplotlib-loaded? "#D1FAE5" "#DBEAFE")
+   [:div {:style {:background-color (if @matplotlib-loaded?
+                                      (get-color "#D1FAE5" "#064E3B")
+                                      (get-color "#DBEAFE" "#1E3A8A"))
                   :border-left (str "4px solid " (if @matplotlib-loaded? "#10B981" "#3B82F6"))
                   :padding "16px"
                   :margin-bottom "24px"
                   :border-radius "4px"}}
     [:p {:style {:font-size "14px"
-                 :color (if @matplotlib-loaded? "#065F46" "#1E40AF")
+                 :color (if @matplotlib-loaded?
+                          (get-color "#065F46" "#6EE7B7")
+                          (get-color "#1E40AF" "#93C5FD"))
                  :margin "0"}}
      (if @matplotlib-loaded?
        "✓ Matplotlib is loaded and ready!"
@@ -158,15 +177,15 @@ plt.axis('equal')"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Quick Examples:"]
     [:div {:style {:display "flex"
                    :gap "8px"
                    :flex-wrap "wrap"}}
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -174,9 +193,9 @@ plt.axis('equal')"})
                :on-click #(load-example! :line-chart)}
       "📈 Line Chart"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -184,9 +203,9 @@ plt.axis('equal')"})
                :on-click #(load-example! :bar-chart)}
       "📊 Bar Chart"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -194,9 +213,9 @@ plt.axis('equal')"})
                :on-click #(load-example! :scatter-plot)}
       "⚫ Scatter Plot"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -209,7 +228,7 @@ plt.axis('equal')"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Python Code (Matplotlib):"]
     [:textarea {:value @code
                 :on-change #(reset! code (.. % -target -value))
@@ -218,11 +237,11 @@ plt.axis('equal')"})
                         :padding "12px"
                         :font-family "monospace"
                         :font-size "14px"
-                        :border "2px solid #D1D5DB"
+                        :border (str "2px solid " (get-color "#D1D5DB" "#4B5563"))
                         :border-radius "6px"
                         :resize "vertical"
-                        :background-color "#FFFFFF"
-                        :color "#111827"}}]]
+                        :background-color (get-color "#FFFFFF" "#1F2937")
+                        :color (get-color "#111827" "#F3F4F6")}}]]
    ;; Generate button
    [:button {:style {:width "100%"
                      :padding "14px 24px"
@@ -246,8 +265,8 @@ plt.axis('equal')"})
       (not @matplotlib-loaded?) "Loading Matplotlib..."
       :else "📊 Generate Chart")]
    ;; Output area
-   [:div {:style {:background-color "#FFFFFF"
-                  :border "2px solid #E5E7EB"
+   [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                  :border (str "2px solid " (get-color "#E5E7EB" "#4B5563"))
                   :border-radius "8px"
                   :padding "20px"
                   :min-height "400px"}}
@@ -255,7 +274,7 @@ plt.axis('equal')"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "12px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Visualization Output:"]
     (if @output-image
       [:div {:style {:text-align "center"}}
@@ -267,7 +286,7 @@ plt.axis('equal')"})
                       :box-shadow "0 2px 8px rgba(0,0,0,0.1)"}}]]
       [:div {:style {:padding "40px"
                      :text-align "center"
-                     :color "#6B7280"
+                     :color (get-color "#6B7280" "#9CA3AF")
                      :font-size "14px"}}
        [:p {:style {:margin "0"}} @output-text]])]])
 

--- a/src/scittle/pyodide/hello_python.cljs
+++ b/src/scittle/pyodide/hello_python.cljs
@@ -9,6 +9,21 @@
 ;; Uses shared pyodide-bridge for state management
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 ;; Local state (output only - Pyodide state is in bridge)
 (defonce output (r/atom "Click 'Initialize Pyodide' to start..."))
 
@@ -51,11 +66,16 @@
   []
   (let [status (pyodide/status)
         badge-style (case status
-                      :not-started {:background-color "#E5E7EB" :color "#374151"}
-                      :loading {:background-color "#DBEAFE" :color "#1E40AF"}
-                      :ready {:background-color "#D1FAE5" :color "#065F46"}
-                      :error {:background-color "#FEE2E2" :color "#991B1B"}
-                      {:background-color "#E5E7EB" :color "#374151"})
+                      :not-started {:background-color (get-color "#E5E7EB" "#4B5563")
+                                    :color (get-color "#374151" "#D1D5DB")}
+                      :loading {:background-color (get-color "#DBEAFE" "#1E3A8A")
+                                :color (get-color "#1E40AF" "#93C5FD")}
+                      :ready {:background-color (get-color "#D1FAE5" "#064E3B")
+                              :color (get-color "#065F46" "#6EE7B7")}
+                      :error {:background-color (get-color "#FEE2E2" "#7F1D1D")
+                              :color (get-color "#991B1B" "#FCA5A5")}
+                      {:background-color (get-color "#E5E7EB" "#4B5563")
+                       :color (get-color "#374151" "#D1D5DB")})
         badge-text (case status
                      :not-started "Not Started"
                      :loading "Loading..."
@@ -66,7 +86,10 @@
                    :align-items "center"
                    :gap "8px"
                    :margin-bottom "16px"}}
-     [:div {:style {:font-size "14px" :font-weight "600"}} "Pyodide Status:"]
+     [:div {:style {:font-size "14px"
+                    :font-weight "600"
+                    :color (get-color "#111827" "#F3F4F6")}}
+      "Pyodide Status:"]
      [:span {:style (merge {:padding "6px 12px"
                             :border-radius "9999px"
                             :font-size "12px"
@@ -127,7 +150,14 @@
 
 (defn output-display
   []
-  [:div.bg-gray-900.text-green-400.p-4.rounded-lg.font-mono.text-sm.min-h-24.whitespace-pre-wrap
+  [:div {:style {:background-color (get-color "#111827" "#0F172A")
+                 :color (get-color "#10B981" "#6EE7B7")
+                 :padding "16px"
+                 :border-radius "8px"
+                 :font-family "monospace"
+                 :font-size "14px"
+                 :min-height "96px"
+                 :white-space "pre-wrap"}}
    @output])
 
 (defn main-component
@@ -137,13 +167,15 @@
                  :padding "24px"}}
    [:h2 {:style {:font-size "24px"
                  :font-weight "bold"
-                 :margin-bottom "16px"}}
+                 :margin-bottom "16px"
+                 :color (get-color "#111827" "#F3F4F6")}}
     "Hello Python! 🐍"]
-   [:div {:style {:background-color "#EFF6FF"
-                  :border-left "4px solid #3B82F6"
+   [:div {:style {:background-color (get-color "#EFF6FF" "#1E3A8A")
+                  :border-left (str "4px solid " (get-color "#3B82F6" "#60A5FA"))
                   :padding "16px"
                   :margin-bottom "24px"}}
-    [:p {:style {:font-size "14px" :color "#374151"}}
+    [:p {:style {:font-size "14px"
+                 :color (get-color "#374151" "#BFDBFE")}}
      "This demo shows the simplest possible Pyodide integration. "
      "Click the button below to load the Python interpreter in your browser, "
      "then try the example buttons!"]]
@@ -168,7 +200,9 @@
      [example-buttons])
    [output-display]
    (when (= (pyodide/status) :ready)
-     [:div {:style {:margin-top "16px" :font-size "12px" :color "#6B7280"}}
+     [:div {:style {:margin-top "16px"
+                    :font-size "12px"
+                    :color (get-color "#6B7280" "#9CA3AF")}}
       [:p "✓ Pyodide is running entirely in your browser"]
       [:p "✓ No server required"]
       [:p "✓ Full Python 3.11 interpreter"]])])

--- a/src/scittle/pyodide/interactive_data_analysis.cljs
+++ b/src/scittle/pyodide/interactive_data_analysis.cljs
@@ -9,6 +9,21 @@
 ;; Upload CSV, analyze with Pandas, visualize results
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 ;; Sample CSV data for quick testing
 (def sample-sales-csv
   "Date,Product,Region,Sales,Profit
@@ -118,17 +133,17 @@
   (let [status (pyodide/status)
         loading @loading?
         badge-config (cond
-                       loading {:color "#3B82F6" :text "Processing..."}
-                       (= status :error) {:color "#EF4444" :text "Error"}
-                       (and (= status :ready) @pandas-ready?) {:color "#10B981" :text "Ready"}
-                       (= status :ready) {:color "#F59E0B" :text "Loading Pandas..."}
-                       (= status :loading) {:color "#3B82F6" :text "Loading Pyodide..."}
-                       :else {:color "#6B7280" :text "Not Started"})]
+                       loading {:color (get-color "#3B82F6" "#60A5FA") :text "Processing..."}
+                       (= status :error) {:color (get-color "#EF4444" "#F87171") :text "Error"}
+                       (and (= status :ready) @pandas-ready?) {:color (get-color "#10B981" "#34D399") :text "Ready"}
+                       (= status :ready) {:color (get-color "#F59E0B" "#FBBF24") :text "Loading Pandas..."}
+                       (= status :loading) {:color (get-color "#3B82F6" "#60A5FA") :text "Loading Pyodide..."}
+                       :else {:color (get-color "#6B7280" "#9CA3AF") :text "Not Started"})]
     [:div {:style {:display "flex"
                    :align-items "center"
                    :gap "12px"
                    :padding "12px 16px"
-                   :background-color "#F9FAFB"
+                   :background-color (get-color "#F9FAFB" "#1F2937")
                    :border-radius "8px"
                    :margin-bottom "20px"}}
      [:div {:style {:display "flex"
@@ -140,13 +155,13 @@
                      :background-color (:color badge-config)}}]
       [:span {:style {:font-size "14px"
                       :font-weight "600"
-                      :color "#374151"}}
+                      :color (get-color "#374151" "#D1D5DB")}}
        "Status: " (:text badge-config)]]]))
 
 (defn file-upload-section
   []
-  [:div {:style {:background-color "#FFFFFF"
-                 :border "2px dashed #D1D5DB"
+  [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                 :border (str "2px dashed " (get-color "#D1D5DB" "#4B5563"))
                  :border-radius "8px"
                  :padding "24px"
                  :margin-bottom "20px"
@@ -154,9 +169,9 @@
    [:h3 {:style {:font-size "18px"
                  :font-weight "bold"
                  :margin-bottom "12px"
-                 :color "#111827"}}
+                 :color (get-color "#111827" "#F3F4F6")}}
     "📤 Upload CSV Data"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "16px"
                 :font-size "14px"}}
     "Upload a CSV file or use the sample data below"]
@@ -179,7 +194,7 @@
    ;; Sample data button
    [:div {:style {:margin-top "12px"}}
     [:button {:style {:padding "10px 20px"
-                      :background-color "#8B5CF6"
+                      :background-color (get-color "#8B5CF6" "#7C3AED")
                       :color "#FFFFFF"
                       :border "none"
                       :border-radius "6px"
@@ -199,77 +214,77 @@
     (when (:success info)
       (let [[rows cols] (:shape info)
             memory (:memory_usage info)]
-        [:div {:style {:background-color "#EFF6FF"
-                       :border "1px solid #BFDBFE"
+        [:div {:style {:background-color (get-color "#EFF6FF" "#1E3A8A")
+                       :border (str "1px solid " (get-color "#BFDBFE" "#3B82F6"))
                        :border-radius "8px"
                        :padding "20px"
                        :margin-bottom "20px"}}
          [:h3 {:style {:font-size "18px"
                        :font-weight "bold"
                        :margin-bottom "16px"
-                       :color "#1E40AF"}}
+                       :color (get-color "#1E40AF" "#93C5FD")}}
           "📊 DataFrame Information"]
          ;; Stats grid
          [:div {:style {:display "grid"
                         :grid-template-columns "repeat(3, 1fr)"
                         :gap "12px"
                         :margin-bottom "16px"}}
-          [:div {:style {:background-color "#FFFFFF"
+          [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
                          :padding "12px"
                          :border-radius "6px"
                          :text-align "center"}}
            [:div {:style {:font-size "12px"
-                          :color "#6B7280"
+                          :color (get-color "#6B7280" "#9CA3AF")
                           :margin-bottom "4px"}}
             "Rows"]
            [:div {:style {:font-size "24px"
                           :font-weight "bold"
-                          :color "#3B82F6"}}
+                          :color (get-color "#3B82F6" "#60A5FA")}}
             rows]]
-          [:div {:style {:background-color "#FFFFFF"
+          [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
                          :padding "12px"
                          :border-radius "6px"
                          :text-align "center"}}
            [:div {:style {:font-size "12px"
-                          :color "#6B7280"
+                          :color (get-color "#6B7280" "#9CA3AF")
                           :margin-bottom "4px"}}
             "Columns"]
            [:div {:style {:font-size "24px"
                           :font-weight "bold"
-                          :color "#10B981"}}
+                          :color (get-color "#10B981" "#34D399")}}
             cols]]
-          [:div {:style {:background-color "#FFFFFF"
+          [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
                          :padding "12px"
                          :border-radius "6px"
                          :text-align "center"}}
            [:div {:style {:font-size "12px"
-                          :color "#6B7280"
+                          :color (get-color "#6B7280" "#9CA3AF")
                           :margin-bottom "4px"}}
             "Memory"]
            [:div {:style {:font-size "24px"
                           :font-weight "bold"
-                          :color "#8B5CF6"}}
+                          :color (get-color "#8B5CF6" "#A78BFA")}}
             memory " KB"]]]
          ;; Column details
          [:div
           [:h4 {:style {:font-size "14px"
                         :font-weight "600"
                         :margin-bottom "8px"
-                        :color "#374151"}}
+                        :color (get-color "#374151" "#D1D5DB")}}
            "Column Types:"]
           [:div {:style {:display "grid"
                          :grid-template-columns "repeat(2, 1fr)"
                          :gap "8px"}}
            (for [[col dtype] (:dtypes info)]
              ^{:key col}
-             [:div {:style {:background-color "#FFFFFF"
+             [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
                             :padding "8px 12px"
                             :border-radius "4px"
                             :display "flex"
                             :justify-content "space-between"
                             :font-size "13px"}}
-              [:span {:style {:color "#374151"}} col]
-              [:span {:style {:color "#6B7280"
+              [:span {:style {:color (get-color "#374151" "#D1D5DB")}} col]
+              [:span {:style {:color (get-color "#6B7280" "#9CA3AF")
                               :font-family "monospace"
                               :font-size "11px"}}
                dtype]])]]]))))
@@ -278,8 +293,8 @@
   []
   (when-let [preview @df-preview]
     (when (:success preview)
-      [:div {:style {:background-color "#FFFFFF"
-                     :border "1px solid #E5E7EB"
+      [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                     :border (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
                      :border-radius "8px"
                      :padding "20px"
                      :margin-bottom "20px"
@@ -287,10 +302,11 @@
        [:h3 {:style {:font-size "18px"
                      :font-weight "bold"
                      :margin-bottom "12px"
-                     :color "#111827"}}
+                     :color (get-color "#111827" "#F3F4F6")}}
         "👁️ Data Preview (First 10 Rows)"]
        [:div {:dangerouslySetInnerHTML {:__html (:html preview)}}]
-       [:style "
+       [:style
+        (str "
          .dataframe-table {
            width: 100%;
            border-collapse: collapse;
@@ -300,24 +316,25 @@
          .dataframe-table th, .dataframe-table td {
            padding: 10px 12px;
            text-align: left;
-           border-bottom: 1px solid #E5E7EB;
+           border-bottom: 1px solid " (get-color "#E5E7EB" "#4B5563") ";
+           color: " (get-color "#111827" "#F3F4F6") ";
          }
          .dataframe-table th {
-           background-color: #F3F4F6;
+           background-color: " (get-color "#F3F4F6" "#374151") ";
            font-weight: 600;
-           color: #374151;
+           color: " (get-color "#374151" "#E5E7EB") ";
          }
          .dataframe-table tr:hover {
-           background-color: #F9FAFB;
+           background-color: " (get-color "#F9FAFB" "#2D3748") ";
          }
-       "]])))
+       ")]])))
 
 (defn dataframe-statistics
   []
   (when-let [stats @df-stats]
     (when (:success stats)
-      [:div {:style {:background-color "#FFFFFF"
-                     :border "1px solid #E5E7EB"
+      [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                     :border (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
                      :border-radius "8px"
                      :padding "20px"
                      :margin-bottom "20px"
@@ -325,10 +342,11 @@
        [:h3 {:style {:font-size "18px"
                      :font-weight "bold"
                      :margin-bottom "12px"
-                     :color "#111827"}}
+                     :color (get-color "#111827" "#F3F4F6")}}
         "📈 Statistical Summary"]
        [:div {:dangerouslySetInnerHTML {:__html (:stats_html stats)}}]
-       [:style "
+       [:style
+        (str "
          .stats-table {
            width: 100%;
            border-collapse: collapse;
@@ -338,23 +356,24 @@
          .stats-table th, .stats-table td {
            padding: 10px 12px;
            text-align: left;
-           border-bottom: 1px solid #E5E7EB;
+           border-bottom: 1px solid " (get-color "#E5E7EB" "#4B5563") ";
+           color: " (get-color "#111827" "#F3F4F6") ";
          }
          .stats-table th {
-           background-color: #F3F4F6;
+           background-color: " (get-color "#F3F4F6" "#374151") ";
            font-weight: 600;
-           color: #374151;
+           color: " (get-color "#374151" "#E5E7EB") ";
          }
          .stats-table tr:hover {
-           background-color: #F9FAFB;
+           background-color: " (get-color "#F9FAFB" "#2D3748") ";
          }
-       "]])))
+       ")]])))
 
 (defn export-section
   []
   (when @df-info
-    [:div {:style {:background-color "#F0FDF4"
-                   :border "1px solid #BBF7D0"
+    [:div {:style {:background-color (get-color "#F0FDF4" "#064E3B")
+                   :border (str "1px solid " (get-color "#BBF7D0" "#10B981"))
                    :border-radius "8px"
                    :padding "16px"
                    :margin-bottom "20px"
@@ -364,15 +383,15 @@
      [:div
       [:h4 {:style {:font-size "16px"
                     :font-weight "600"
-                    :color "#166534"
+                    :color (get-color "#166534" "#6EE7B7")
                     :margin-bottom "4px"}}
        "💾 Export Data"]
       [:p {:style {:font-size "14px"
-                   :color "#15803D"
+                   :color (get-color "#15803D" "#86EFAC")
                    :margin "0"}}
        "Download the processed DataFrame as CSV"]]
      [:button {:style {:padding "10px 20px"
-                       :background-color "#10B981"
+                       :background-color (get-color "#10B981" "#059669")
                        :color "#FFFFFF"
                        :border "none"
                        :border-radius "6px"
@@ -385,18 +404,18 @@
 (defn error-display
   []
   (when @error-msg
-    [:div {:style {:background-color "#FEE2E2"
-                   :border "1px solid #FCA5A5"
+    [:div {:style {:background-color (get-color "#FEE2E2" "#7F1D1D")
+                   :border (str "1px solid " (get-color "#FCA5A5" "#EF4444"))
                    :border-radius "8px"
                    :padding "16px"
                    :margin-bottom "20px"}}
      [:h4 {:style {:font-size "16px"
                    :font-weight "600"
-                   :color "#991B1B"
+                   :color (get-color "#991B1B" "#FCA5A5")
                    :margin-bottom "8px"}}
       "⚠️ Error"]
      [:p {:style {:font-size "14px"
-                  :color "#DC2626"
+                  :color (get-color "#DC2626" "#FEE2E2")
                   :margin "0"}}
       @error-msg]]))
 
@@ -413,12 +432,12 @@
                     :gap "16px"}}
       [:div {:style {:width "48px"
                      :height "48px"
-                     :border "4px solid #E5E7EB"
-                     :border-top-color "#3B82F6"
+                     :border (str "4px solid " (get-color "#E5E7EB" "#4B5563"))
+                     :border-top-color (get-color "#3B82F6" "#60A5FA")
                      :border-radius "50%"
                      :animation "spin 1s linear infinite"}}]
       [:p {:style {:font-size "16px"
-                   :color "#6B7280"
+                   :color (get-color "#6B7280" "#9CA3AF")
                    :font-weight "500"}}
        "Analyzing data..."]
       [:style "@keyframes spin { to { transform: rotate(360deg); } }"]]]))
@@ -433,18 +452,19 @@
                  :margin-bottom "8px"
                  :background "linear-gradient(to right, #3B82F6, #8B5CF6)"
                  :-webkit-background-clip "text"
-                 :-webkit-text-fill-color "transparent"}}
+                 :-webkit-text-fill-color "transparent"
+                 :background-clip "text"}}
     "🐍 Interactive Data Analysis"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "24px"
                 :font-size "16px"}}
     "Upload CSV data and analyze it with Pandas - all in your browser!"]
-   [:div {:style {:background-color "#EFF6FF"
-                  :border-left "4px solid #3B82F6"
+   [:div {:style {:background-color (get-color "#EFF6FF" "#1E3A8A")
+                  :border-left (str "4px solid " (get-color "#3B82F6" "#60A5FA"))
                   :padding "16px"
                   :margin-bottom "24px"}}
     [:p {:style {:font-size "14px"
-                 :color "#1E40AF"
+                 :color (get-color "#1E40AF" "#BFDBFE")
                  :margin "0"}}
      "💡 This demo shows how to upload CSV files, create Pandas DataFrames, "
      "and perform data analysis entirely in the browser using Pyodide."]]
@@ -466,8 +486,8 @@
    ;; Footer
    [:div {:style {:margin-top "32px"
                   :padding-top "24px"
-                  :border-top "1px solid #E5E7EB"
-                  :color "#6B7280"
+                  :border-top (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
+                  :color (get-color "#6B7280" "#9CA3AF")
                   :font-size "14px"}}
     [:p "✨ " [:strong "Features:"]]
     [:ul {:style {:margin "8px 0"

--- a/src/scittle/pyodide/pandas_demo.cljs
+++ b/src/scittle/pyodide/pandas_demo.cljs
@@ -5,6 +5,21 @@
    [scittle.pyodide.pyodide-bridge :as pyodide]))
 
 ;; ============================================================================
+;; Dark Mode Helpers
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
+;; ============================================================================
 ;; Pandas DataFrame Analysis Demo
 ;; ============================================================================
 
@@ -198,20 +213,24 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
    [:h2 {:style {:font-size "28px"
                  :font-weight "bold"
                  :margin-bottom "8px"
-                 :color "#111827"}}
+                 :color (get-color "#111827" "#F3F4F6")}}
     "🐼 DataFrame Analysis with Pandas"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "24px"
                 :font-size "16px"}}
     "Analyze and manipulate data using Python's pandas library for powerful data science workflows in your browser!"]
    ;; Info banner
-   [:div {:style {:background-color (if @pandas-loaded? "#D1FAE5" "#DBEAFE")
+   [:div {:style {:background-color (if @pandas-loaded?
+                                      (get-color "#D1FAE5" "#064E3B")
+                                      (get-color "#DBEAFE" "#1E3A8A"))
                   :border-left (str "4px solid " (if @pandas-loaded? "#10B981" "#3B82F6"))
                   :padding "16px"
                   :margin-bottom "24px"
                   :border-radius "4px"}}
     [:p {:style {:font-size "14px"
-                 :color (if @pandas-loaded? "#065F46" "#1E40AF")
+                 :color (if @pandas-loaded?
+                          (get-color "#065F46" "#6EE7B7")
+                          (get-color "#1E40AF" "#93C5FD"))
                  :margin "0"}}
      (if @pandas-loaded?
        "✓ Pandas is loaded and ready!"
@@ -222,15 +241,15 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Quick Examples:"]
     [:div {:style {:display "flex"
                    :gap "8px"
                    :flex-wrap "wrap"}}
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -238,9 +257,9 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                :on-click #(load-example! :basic-dataframe)}
       "📋 Basic DataFrame"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -248,9 +267,9 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                :on-click #(load-example! :statistics)}
       "📊 Statistics"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -258,9 +277,9 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                :on-click #(load-example! :filtering)}
       "🔍 Filtering"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -268,9 +287,9 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                :on-click #(load-example! :grouping)}
       "📈 Grouping"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#E5E7EB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#6B7280"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -283,7 +302,7 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Python Code (Pandas):"]
     [:textarea {:value @code
                 :on-change #(reset! code (.. % -target -value))
@@ -292,11 +311,11 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                         :padding "12px"
                         :font-family "monospace"
                         :font-size "14px"
-                        :border "2px solid #D1D5DB"
+                        :border (str "2px solid " (get-color "#D1D5DB" "#4B5563"))
                         :border-radius "6px"
                         :resize "vertical"
-                        :background-color "#FFFFFF"
-                        :color "#111827"}}]]
+                        :background-color (get-color "#FFFFFF" "#1F2937")
+                        :color (get-color "#111827" "#F3F4F6")}}]]
    ;; Run button
    [:button {:style {:width "100%"
                      :padding "14px 24px"
@@ -320,8 +339,8 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
       (not @pandas-loaded?) "Loading Pandas..."
       :else "🐼 Run Analysis")]
    ;; Output area
-   [:div {:style {:background-color "#FFFFFF"
-                  :border "2px solid #E5E7EB"
+   [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                  :border (str "2px solid " (get-color "#E5E7EB" "#4B5563"))
                   :border-radius "8px"
                   :padding "20px"
                   :min-height "400px"}}
@@ -329,12 +348,12 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "12px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Analysis Results:"]
     (if @output-html
       [:div {:style {:overflow-x "auto"}}
-       ;; Add custom CSS for pandas tables
-       [:style "
+       ;; Add custom CSS for pandas tables with dark mode support
+       [:style (str "
 .dataframe {
   border-collapse: collapse;
   width: 100%;
@@ -343,32 +362,33 @@ print(df.to_html(index=False, border=0, classes='dataframe'))"})
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 .dataframe thead tr {
-  background-color: #F3F4F6;
+  background-color: " (get-color "#F3F4F6" "#374151") ";
   text-align: left;
   font-weight: 600;
-  color: #374151;
+  color: " (get-color "#374151" "#E5E7EB") ";
 }
 .dataframe th,
 .dataframe td {
   padding: 12px 15px;
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 1px solid " (get-color "#E5E7EB" "#4B5563") ";
+  color: " (get-color "#111827" "#F3F4F6") ";
 }
 .dataframe tbody tr:hover {
-  background-color: #F9FAFB;
+  background-color: " (get-color "#F9FAFB" "#2D3748") ";
 }
 .dataframe tbody tr:last-of-type {
-  border-bottom: 2px solid #D1D5DB;
+  border-bottom: 2px solid " (get-color "#D1D5DB" "#6B7280") ";
 }
 h4 {
-  color: #374151;
+  color: " (get-color "#374151" "#D1D5DB") ";
   font-size: 16px;
   font-weight: 600;
   margin: 20px 0 10px 0;
-}"]
+}")]
        [:div {:dangerouslySetInnerHTML {:__html @output-html}}]]
       [:div {:style {:padding "40px"
                      :text-align "center"
-                     :color "#6B7280"
+                     :color (get-color "#6B7280" "#9CA3AF")
                      :font-size "14px"}}
        [:p {:style {:margin "0"}} @output-text]])]])
 

--- a/src/scittle/pyodide/pandas_viz_demo.cljs
+++ b/src/scittle/pyodide/pandas_viz_demo.cljs
@@ -8,6 +8,21 @@
 ;; Combined Pandas + Matplotlib Demo - Complete Data Science Workflows
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 (defonce code (r/atom "# Sales Trend Analysis - Complete Workflow
 import pandas as pd
 import numpy as np
@@ -363,20 +378,26 @@ plt.tight_layout()"})
    [:h2 {:style {:font-size "28px"
                  :font-weight "bold"
                  :margin-bottom "8px"
-                 :color "#111827"}}
+                 :color (get-color "#111827" "#F3F4F6")}}
     "🎯 Complete Data Science Workflows"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "24px"
                 :font-size "16px"}}
     "Combine Pandas data analysis with Matplotlib visualizations for complete end-to-end workflows!"]
    ;; Info banner
-   [:div {:style {:background-color (if @libs-loaded? "#D1FAE5" "#DBEAFE")
-                  :border-left (str "4px solid " (if @libs-loaded? "#10B981" "#3B82F6"))
+   [:div {:style {:background-color (if @libs-loaded?
+                                      (get-color "#D1FAE5" "#064E3B")
+                                      (get-color "#DBEAFE" "#1E3A8A"))
+                  :border-left (str "4px solid " (if @libs-loaded?
+                                                   (get-color "#10B981" "#34D399")
+                                                   (get-color "#3B82F6" "#60A5FA")))
                   :padding "16px"
                   :margin-bottom "24px"
                   :border-radius "4px"}}
     [:p {:style {:font-size "14px"
-                 :color (if @libs-loaded? "#065F46" "#1E40AF")
+                 :color (if @libs-loaded?
+                          (get-color "#065F46" "#6EE7B7")
+                          (get-color "#1E40AF" "#BFDBFE"))
                  :margin "0"}}
      (if @libs-loaded?
        "✓ Pandas & Matplotlib are loaded and ready!"
@@ -387,15 +408,15 @@ plt.tight_layout()"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Complete Workflow Examples:"]
     [:div {:style {:display "flex"
                    :gap "8px"
                    :flex-wrap "wrap"}}
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#D1D5DB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#4B5563"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -403,9 +424,9 @@ plt.tight_layout()"})
                :on-click #(load-example! :sales-trend)}
       "📈 Sales Trend"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#D1D5DB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#4B5563"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -413,9 +434,9 @@ plt.tight_layout()"})
                :on-click #(load-example! :product-analysis)}
       "📦 Product Analysis"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#D1D5DB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#4B5563"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -423,9 +444,9 @@ plt.tight_layout()"})
                :on-click #(load-example! :regional-breakdown)}
       "🗺️ Regional Analysis"]
      [:button {:style {:padding "8px 16px"
-                       :background-color "#F3F4F6"
-                       :color "#374151"
-                       :border "1px solid #D1D5DB"
+                       :background-color (get-color "#F3F4F6" "#374151")
+                       :color (get-color "#374151" "#D1D5DB")
+                       :border (str "1px solid " (get-color "#D1D5DB" "#4B5563"))
                        :border-radius "6px"
                        :font-size "14px"
                        :cursor "pointer"
@@ -438,7 +459,7 @@ plt.tight_layout()"})
                      :font-size "14px"
                      :font-weight "600"
                      :margin-bottom "8px"
-                     :color "#374151"}}
+                     :color (get-color "#374151" "#D1D5DB")}}
      "Python Code (Pandas + Matplotlib):"]
     [:textarea {:value @code
                 :on-change #(reset! code (.. % -target -value))
@@ -447,11 +468,11 @@ plt.tight_layout()"})
                         :padding "12px"
                         :font-family "monospace"
                         :font-size "13px"
-                        :border "2px solid #D1D5DB"
+                        :border (str "2px solid " (get-color "#D1D5DB" "#4B5563"))
                         :border-radius "6px"
                         :resize "vertical"
-                        :background-color "#FFFFFF"
-                        :color "#111827"
+                        :background-color (get-color "#FFFFFF" "#1F2937")
+                        :color (get-color "#111827" "#F3F4F6")
                         :line-height "1.5"}}]]
    ;; Run button
    [:button {:style {:width "100%"
@@ -476,8 +497,8 @@ plt.tight_layout()"})
       (not @libs-loaded?) "Loading Libraries..."
       :else "🎯 Run Complete Workflow")]
    ;; Output area
-   [:div {:style {:background-color "#FFFFFF"
-                  :border "2px solid #E5E7EB"
+   [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                  :border (str "2px solid " (get-color "#E5E7EB" "#4B5563"))
                   :border-radius "8px"
                   :padding "20px"
                   :min-height "500px"}}
@@ -492,7 +513,8 @@ plt.tight_layout()"})
        ;; Tables section
        (when @output-html
          [:div {:style {:margin-bottom "24px"}}
-          [:style "
+          [:style
+           (str "
 .dataframe {
   border-collapse: collapse;
   width: 100%;
@@ -501,44 +523,45 @@ plt.tight_layout()"})
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 .dataframe thead tr {
-  background-color: #F3F4F6;
+  background-color: " (get-color "#F3F4F6" "#374151") ";
   text-align: left;
   font-weight: 600;
-  color: #374151;
+  color: " (get-color "#374151" "#E5E7EB") ";
 }
 .dataframe th,
 .dataframe td {
   padding: 12px 15px;
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 1px solid " (get-color "#E5E7EB" "#4B5563") ";
   text-align: left;
+  color: " (get-color "#111827" "#F3F4F6") ";
 }
 .dataframe tbody tr:hover {
-  background-color: #F9FAFB;
+  background-color: " (get-color "#F9FAFB" "#2D3748") ";
 }
 .dataframe tbody tr:last-of-type {
-  border-bottom: 2px solid #D1D5DB;
+  border-bottom: 2px solid " (get-color "#D1D5DB" "#6B7280") ";
 }
 h3 {
-  color: #374151;
+  color: " (get-color "#374151" "#D1D5DB") ";
   font-size: 18px;
   font-weight: 600;
   margin: 24px 0 12px 0;
   padding-bottom: 8px;
-  border-bottom: 2px solid #E5E7EB;
-}"]
+  border-bottom: 2px solid " (get-color "#E5E7EB" "#4B5563") ";
+}")]
           [:div {:dangerouslySetInnerHTML {:__html @output-html}}]])
        ;; Visualization section
        (when @output-image
          [:div {:style {:margin-top "24px"
                         :padding-top "24px"
-                        :border-top "2px solid #E5E7EB"}}
-          [:h3 {:style {:color "#374151"
+                        :border-top (str "2px solid " (get-color "#E5E7EB" "#4B5563"))}}
+          [:h3 {:style {:color (get-color "#374151" "#D1D5DB")
                         :font-size "18px"
                         :font-weight "600"
                         :margin-bottom "16px"}}
            "📊 Visualizations"]
           [:div {:style {:text-align "center"
-                         :background-color "#F9FAFB"
+                         :background-color (get-color "#F9FAFB" "#1F2937")
                          :padding "20px"
                          :border-radius "8px"}}
            [:img {:src (str "data:image/png;base64," @output-image)
@@ -550,7 +573,7 @@ h3 {
     (when (and (not @output-html) (not @output-image))
       [:div {:style {:padding "60px 40px"
                      :text-align "center"
-                     :color "#6B7280"
+                     :color (get-color "#6B7280" "#9CA3AF")
                      :font-size "14px"}}
        [:p {:style {:margin "0"}} @output-text]])]])
 

--- a/src/scittle/pyodide/time_series_demo.cljs
+++ b/src/scittle/pyodide/time_series_demo.cljs
@@ -9,6 +9,21 @@
 ;; Moving averages, trends, seasonality analysis
 ;; ============================================================================
 
+;; ============================================================================
+;; Dark Mode Support
+;; ============================================================================
+
+(defn dark-mode?
+  "Check if dark mode is currently active by looking for 'quarto-dark' class on body"
+  []
+  (when-let [body (js/document.querySelector "body")]
+    (.contains (.-classList body) "quarto-dark")))
+
+(defn get-color
+  "Get appropriate color based on dark mode state"
+  [light-color dark-color]
+  (if (dark-mode?) dark-color light-color))
+
 ;; Sample time series data
 (def sample-stock-data
   "Date,Price,Volume
@@ -348,23 +363,29 @@ output
 
 (defn dataset-selector
   []
-  [:div {:style {:background-color "#FFFFFF"
-                 :border "1px solid #E5E7EB"
+  [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                 :border (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
                  :border-radius "8px"
                  :padding "20px"
                  :margin-bottom "20px"}}
    [:h3 {:style {:font-size "18px"
                  :font-weight "bold"
                  :margin-bottom "12px"
-                 :color "#111827"}}
+                 :color (get-color "#111827" "#F3F4F6")}}
     "📊 Select Dataset"]
    [:div {:style {:display "grid"
                   :grid-template-columns "1fr 1fr"
                   :gap "12px"}}
     [:button {:style {:padding "16px"
-                      :background-color (if (= @current-dataset :stock) "#3B82F6" "#FFFFFF")
-                      :color (if (= @current-dataset :stock) "#FFFFFF" "#374151")
-                      :border (str "2px solid " (if (= @current-dataset :stock) "#3B82F6" "#D1D5DB"))
+                      :background-color (if (= @current-dataset :stock)
+                                          (get-color "#3B82F6" "#2563EB")
+                                          (get-color "#FFFFFF" "#1F2937"))
+                      :color (if (= @current-dataset :stock)
+                               "#FFFFFF"
+                               (get-color "#374151" "#D1D5DB"))
+                      :border (str "2px solid " (if (= @current-dataset :stock)
+                                                  (get-color "#3B82F6" "#2563EB")
+                                                  (get-color "#D1D5DB" "#4B5563")))
                       :border-radius "8px"
                       :font-weight "600"
                       :cursor "pointer"
@@ -381,9 +402,15 @@ output
       "Price, volume, moving averages"]]
 
     [:button {:style {:padding "16px"
-                      :background-color (if (= @current-dataset :sensor) "#10B981" "#FFFFFF")
-                      :color (if (= @current-dataset :sensor) "#FFFFFF" "#374151")
-                      :border (str "2px solid " (if (= @current-dataset :sensor) "#10B981" "#D1D5DB"))
+                      :background-color (if (= @current-dataset :sensor)
+                                          (get-color "#10B981" "#059669")
+                                          (get-color "#FFFFFF" "#1F2937"))
+                      :color (if (= @current-dataset :sensor)
+                               "#FFFFFF"
+                               (get-color "#374151" "#D1D5DB"))
+                      :border (str "2px solid " (if (= @current-dataset :sensor)
+                                                  (get-color "#10B981" "#059669")
+                                                  (get-color "#D1D5DB" "#4B5563")))
                       :border-radius "8px"
                       :font-weight "600"
                       :cursor "pointer"
@@ -405,15 +432,15 @@ output
     [:div {:style {:space-y "24px"}}
      (for [[idx plot] (map-indexed vector @plots)]
        ^{:key idx}
-       [:div {:style {:background-color "#FFFFFF"
-                      :border "1px solid #E5E7EB"
+       [:div {:style {:background-color (get-color "#FFFFFF" "#1F2937")
+                      :border (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
                       :border-radius "8px"
                       :padding "20px"
                       :margin-bottom "20px"}}
         [:h3 {:style {:font-size "18px"
                       :font-weight "bold"
                       :margin-bottom "12px"
-                      :color "#111827"}}
+                      :color (get-color "#111827" "#F3F4F6")}}
          (:title plot)]
         [:img {:src (str "data:image/png;base64," (:data plot))
                :style {:max-width "100%"
@@ -435,12 +462,12 @@ output
                     :gap "16px"}}
       [:div {:style {:width "48px"
                      :height "48px"
-                     :border "4px solid #E5E7EB"
-                     :border-top-color "#3B82F6"
+                     :border (str "4px solid " (get-color "#E5E7EB" "#4B5563"))
+                     :border-top-color (get-color "#3B82F6" "#60A5FA")
                      :border-radius "50%"
                      :animation "spin 1s linear infinite"}}]
       [:p {:style {:font-size "16px"
-                   :color "#6B7280"
+                   :color (get-color "#6B7280" "#9CA3AF")
                    :font-weight "500"}}
        "Analyzing time series data..."]
       [:style "@keyframes spin { to { transform: rotate(360deg); } }"]]]))
@@ -448,18 +475,18 @@ output
 (defn error-display
   []
   (when @error-msg
-    [:div {:style {:background-color "#FEE2E2"
-                   :border "1px solid #FCA5A5"
+    [:div {:style {:background-color (get-color "#FEE2E2" "#7F1D1D")
+                   :border (str "1px solid " (get-color "#FCA5A5" "#EF4444"))
                    :border-radius "8px"
                    :padding "16px"
                    :margin-bottom "20px"}}
      [:h4 {:style {:font-size "16px"
                    :font-weight "600"
-                   :color "#991B1B"
+                   :color (get-color "#991B1B" "#FCA5A5")
                    :margin-bottom "8px"}}
       "⚠️ Error"]
      [:p {:style {:font-size "14px"
-                  :color "#DC2626"
+                  :color (get-color "#DC2626" "#FEE2E2")
                   :margin "0"}}
       @error-msg]]))
 
@@ -473,18 +500,19 @@ output
                  :margin-bottom "8px"
                  :background "linear-gradient(to right, #3B82F6, #10B981)"
                  :-webkit-background-clip "text"
-                 :-webkit-text-fill-color "transparent"}}
+                 :-webkit-text-fill-color "transparent"
+                 :background-clip "text"}}
     "📈 Time Series Analysis"]
-   [:p {:style {:color "#6B7280"
+   [:p {:style {:color (get-color "#6B7280" "#9CA3AF")
                 :margin-bottom "24px"
                 :font-size "16px"}}
     "Analyze temporal patterns with moving averages, trends, and volatility"]
-   [:div {:style {:background-color "#EFF6FF"
-                  :border-left "4px solid #3B82F6"
+   [:div {:style {:background-color (get-color "#EFF6FF" "#1E3A8A")
+                  :border-left (str "4px solid " (get-color "#3B82F6" "#60A5FA"))
                   :padding "16px"
                   :margin-bottom "24px"}}
     [:p {:style {:font-size "14px"
-                 :color "#1E40AF"
+                 :color (get-color "#1E40AF" "#BFDBFE")
                  :margin "0"}}
      "💡 Explore how time series data reveals patterns, trends, and relationships. "
      "This demo uses Pandas for data manipulation and Matplotlib for visualization."]]
@@ -497,8 +525,8 @@ output
    (when (seq @plots)
      [:div {:style {:margin-top "32px"
                     :padding-top "24px"
-                    :border-top "1px solid #E5E7EB"
-                    :color "#6B7280"
+                    :border-top (str "1px solid " (get-color "#E5E7EB" "#4B5563"))
+                    :color (get-color "#6B7280" "#9CA3AF")
                     :font-size "14px"}}
       [:p "✨ " [:strong "Time Series Techniques:"]]
       [:ul {:style {:margin "8px 0"


### PR DESCRIPTION
- Add dark-mode? helper function to detect quarto-dark class
- Add get-color helper for dynamic light/dark color selection
- Update all 8 Pyodide demo components with dark mode styling:
  * code_editor.cljs - textarea, labels, buttons, output areas
  * hello_python.cljs - status badges, example buttons, output display
  * pandas_demo.cljs - dataframe tables with dynamic CSS
  * data_visualization.cljs - chart displays and controls
  * interactive_data_analysis.cljs - all 9 UI components
  * time_series_demo.cljs - dataset selector, plots, spinners
  * pandas_viz_demo.cljs - workflow buttons, code editor, tables
  * code_executor.cljs - code textarea styling

- Improve readability in dark mode with proper contrast ratios
- Ensure consistent styling across all components
- Use Tailwind-compatible color palette for seamless integration

Example Output:

<img width="2560" height="8532" alt="scittle-pyodide-pyodide-integration" src="https://github.com/user-attachments/assets/96781bb7-a872-48a1-84cb-407f9cd3c315" />
