### PR TITLE
feat: Add CSS variable-based dark mode logic

### DIFF
--- a/src/scittle/qrcode/qr_code_scanner.clj
+++ b/src/scittle/qrcode/qr_code_scanner.clj
@@ -193,6 +193,7 @@
    :on-error (fn [error] ...)})")
 
 ;; Benefits of keyword arguments:
+;;
 ;; - **Self-documenting** - Clear what each parameter does
 ;; - **Flexible** - Order doesn't matter
 ;; - **Optional parameters** - Easy to add defaults
@@ -203,15 +204,18 @@
 ;; The scanner has several key functions:
 
 ;; **Camera Management:**
+;;
 ;; - `start-stream!` - Request camera access with callbacks
 ;; - `stop-stream!` - Clean up camera resources
 
 ;; **Scanning Functions:**
+;;
 ;; - `scan-qr-code` - Capture frame and detect QR codes
 ;; - `start-qr-scanning!` - Begin continuous scanning loop
 ;; - `stop-qr-scanning!` - Stop the scanning loop
 
 ;; **Utility Functions:**
+;;
 ;; - `copy-to-clipboard!` - Copy results to clipboard
 ;; - `clear-qr-results!` - Clear all scanned results
 ;; - `generate-id` - Create unique IDs for results

--- a/src/scittle/qrcode/qr_scanner.cljs
+++ b/src/scittle/qrcode/qr_scanner.cljs
@@ -50,7 +50,7 @@
 
 (defn show-toast!
   "Show a success toast message
-  
+
   Usage:
     (show-toast! {:message \"QR Code detected!\"})"
   [{:keys [message duration]}]
@@ -90,9 +90,9 @@
 
 (defn start-stream!
   "Start camera stream
-  
+
   Usage:
-    (start-stream! 
+    (start-stream!
       {:on-success (fn [stream] ...)
        :on-error (fn [error] ...)})"
   [{:keys [on-success on-error]}]
@@ -112,7 +112,7 @@
 
 (defn scan-qr-code
   "Scan for QR code in video feed
-  
+
   Usage:
     (scan-qr-code
       {:video-element video-el
@@ -152,7 +152,7 @@
 
 (defn start-qr-scanning!
   "Start continuous QR code scanning
-  
+
   Usage:
     (start-qr-scanning!
       {:video-element video-el
@@ -188,7 +188,7 @@
 
 (defn copy-to-clipboard!
   "Copy text to clipboard
-  
+
   Usage:
     (copy-to-clipboard!
       {:text \"Hello World\"

--- a/src/scittle/weather/complete_dashboard.cljs
+++ b/src/scittle/weather/complete_dashboard.cljs
@@ -6,6 +6,52 @@
             [clojure.string :as str]))
 
 ;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
+;; ============================================================================
 ;; API Functions (Consolidated)
 ;; ============================================================================
 
@@ -82,16 +128,20 @@
 ;; Utilities (from previous demos)
 ;; ============================================================================
 
-(defn celsius-to-fahrenheit [c]
+(defn celsius-to-fahrenheit
+  [c]
   (when c (+ (* c 1.8) 32)))
 
-(defn fahrenheit-to-celsius [f]
+(defn fahrenheit-to-celsius
+  [f]
   (when f (* (- f 32) 0.5556)))
 
-(defn fahrenheit-to-kelvin [f]
+(defn fahrenheit-to-kelvin
+  [f]
   (when f (+ (fahrenheit-to-celsius f) 273.15)))
 
-(defn format-temp [fahrenheit unit]
+(defn format-temp
+  [fahrenheit unit]
   (when fahrenheit
     (case unit
       "F" (str fahrenheit "°F")
@@ -99,7 +149,8 @@
       "K" (str (Math/round (fahrenheit-to-kelvin fahrenheit)) "K")
       (str fahrenheit "°F"))))
 
-(defn get-weather-icon [short-forecast]
+(defn get-weather-icon
+  [short-forecast]
   (let [forecast-lower (str/lower-case (or short-forecast ""))]
     (cond
       (re-find #"thunder|tstorm" forecast-lower) "⛈️"
@@ -146,12 +197,13 @@
    :opacity "0.8"})
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "12px"
    :padding "24px"
    :margin-bottom "20px"
-   :box-shadow "0 2px 8px rgba(0,0,0,0.1)"})
+   :box-shadow "0 2px 8px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def location-search-style
   {:display "grid"
@@ -161,9 +213,12 @@
 
 (def input-style
   {:padding "12px 15px"
-   :border "1px solid #ddd"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "8px"
-   :font-size "14px"})
+   :font-size "14px"
+   :box-shadow "inset 0 1px 2px var(--shadow-color, rgba(0,0,0,0.05))"})
 
 (def button-primary-style
   {:padding "12px 24px"
@@ -174,7 +229,8 @@
    :cursor "pointer"
    :font-size "14px"
    :font-weight "600"
-   :transition "all 0.2s"})
+   :transition "all 0.2s"
+   :box-shadow "0 2px 4px rgba(0,0,0,0.3)"})
 
 (def quick-cities-grid-style
   {:display "grid"
@@ -184,18 +240,21 @@
 
 (def city-button-style
   {:padding "10px"
-   :background "#f3f4f6"
-   :border "1px solid #e5e7eb"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "8px"
    :cursor "pointer"
    :font-size "13px"
+   :font-weight "500"
    :text-align "center"
-   :transition "all 0.2s"})
+   :transition "all 0.2s"
+   :box-shadow "0 1px 2px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def tabs-container-style
   {:display "flex"
    :gap "5px"
-   :border-bottom "2px solid #e5e7eb"
+   :border-bottom "2px solid #374151"
    :margin-bottom "20px"})
 
 (defn tab-style [active?]
@@ -215,7 +274,7 @@
    :justify-content "space-between"
    :align-items "center"
    :padding "15px"
-   :background "#f9fafb"
+   :background "var(--card-secondary-bg, #f9fafb)"
    :border-radius "8px"
    :margin-bottom "20px"
    :flex-wrap "wrap"
@@ -229,7 +288,7 @@
 (def setting-label-style
   {:font-size "14px"
    :font-weight "500"
-   :color "#4b5563"})
+   :color "var(--text-secondary, #6b7280)"})
 
 (def toggle-buttons-style
   {:display "flex"
@@ -237,9 +296,9 @@
 
 (defn toggle-button-style [active?]
   {:padding "6px 14px"
-   :background (if active? "#3b82f6" "white")
-   :color (if active? "white" "#6b7280")
-   :border "1px solid #d1d5db"
+   :background (if active? "#3b82f6" "var(--button-bg, #f3f4f6)")
+   :color (if active? "white" "var(--button-text, #374151)")
+   :border (if active? "1px solid #3b82f6" "1px solid var(--border-color-dark, #d1d5db)")
    :border-radius "6px"
    :cursor "pointer"
    :font-size "13px"
@@ -257,13 +316,13 @@
 (def temp-display-style
   {:font-size "72px"
    :font-weight "300"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :line-height "1"
    :margin "0"})
 
 (def condition-text-style
   {:font-size "18px"
-   :color "#6b7280"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin "10px 0"})
 
 (def metrics-quick-grid-style
@@ -273,19 +332,20 @@
 
 (def metric-item-style
   {:padding "12px"
-   :background "#f9fafb"
+   :background "var(--card-secondary-bg, #f9fafb)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "8px"})
 
 (def metric-label-style
   {:font-size "12px"
-   :color "#6b7280"
+   :color "#9ca3af"
    :margin-bottom "5px"
    :text-transform "uppercase"
    :font-weight "600"})
 
 (def metric-value-style
   {:font-size "20px"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :font-weight "500"})
 
 (def forecast-mini-grid-style
@@ -295,14 +355,15 @@
 
 (def forecast-mini-card-style
   {:padding "15px"
-   :background "#f9fafb"
+   :background "var(--card-secondary-bg, #f9fafb)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "8px"
    :text-align "center"})
 
 (def loading-style
   {:text-align "center"
    :padding "60px"
-   :color "#6b7280"})
+   :color "#9ca3af"})
 
 ;; ============================================================================
 ;; Quick Cities
@@ -354,9 +415,7 @@
       ^{:key (:name city)}
       [:button
        {:style city-button-style
-        :on-click #(on-city-select city)
-        :on-mouse-over #(set! (.. % -target -style -background) "#e5e7eb")
-        :on-mouse-out #(set! (.. % -target -style -background) "#f3f4f6")}
+        :on-click #(on-city-select city)}
        (:name city)])]])
 
 (defn settings-bar [{:keys [unit on-unit-change]}]
@@ -371,7 +430,7 @@
          :on-click #(on-unit-change u)}
         u])]]
 
-   [:div {:style {:font-size "13px" :color "#6b7280"}}
+   [:div {:style {:font-size "13px" :color "#9ca3af"}}
     "🔄 Auto-refresh: Off"]])
 
 (defn tabs-navigation [{:keys [active-tab on-tab-change]}]
@@ -432,7 +491,7 @@
          (get-weather-icon (:shortForecast period))]
         [:div {:style {:font-size "24px" :font-weight "600" :color "#3b82f6"}}
          (format-temp (:temperature period) unit)]
-        [:div {:style {:font-size "13px" :color "#6b7280" :margin-top "8px"}}
+        [:div {:style {:font-size "13px" :color "#9ca3af" :margin-top "8px"}}
          (:shortForecast period)]])]))
 
 (defn hourly-view [{:keys [hourly unit]}]
@@ -459,7 +518,7 @@
        [:div {:style {:font-size "64px"}} "✅"]
        [:div {:style {:font-size "18px" :font-weight "500" :margin-top "15px"}}
         "No Active Weather Alerts"]
-       [:div {:style {:font-size "14px" :color "#6b7280" :margin-top "8px"}}
+       [:div {:style {:font-size "14px" :color "#9ca3af" :margin-top "8px"}}
         "All clear! No weather warnings or advisories."]]
 
       [:div
@@ -552,33 +611,35 @@
           (fetch-all-weather))]
 
     (fn []
-      [:div {:style app-container-style}
-       [:div {:style header-card-style}
-        [:h1 {:style app-title-style}
-         [:span "☀️"] [:span "Weather Dashboard"]]
-        (when @location-name
-          [:div {:style location-header-style}
-           "📍 " @location-name])
-        (when @last-updated
-          [:div {:style last-updated-style}
-           "Last updated: " (.toLocaleTimeString @last-updated)])]
+      [:div
+       [theme-styles]
+       [:div {:style app-container-style}
+        [:div {:style header-card-style}
+         [:h1 {:style app-title-style}
+          [:span "☀️"] [:span "Weather Dashboard"]]
+         (when @location-name
+           [:div {:style location-header-style}
+            "📍 " @location-name])
+         (when @last-updated
+           [:div {:style last-updated-style}
+            "Last updated: " (.toLocaleTimeString @last-updated)])]
 
-       [location-search-panel
-        {:lat @lat
-         :lon @lon
-         :on-lat-change #(reset! lat %)
-         :on-lon-change #(reset! lon %)
-         :on-fetch fetch-all-weather
-         :cities quick-cities
-         :on-city-select select-city}]
+        [location-search-panel
+         {:lat @lat
+          :lon @lon
+          :on-lat-change #(reset! lat %)
+          :on-lon-change #(reset! lon %)
+          :on-fetch fetch-all-weather
+          :cities quick-cities
+          :on-city-select select-city}]
 
-       (cond
-         @loading? [loading-spinner]
-         @weather-data [weather-dashboard
-                        {:weather-data @weather-data
-                         :location-name @location-name
-                         :unit @unit
-                         :on-unit-change #(reset! unit %)}])])))
+        (cond
+          @loading? [loading-spinner]
+          @weather-data [weather-dashboard
+                         {:weather-data @weather-data
+                          :location-name @location-name
+                          :unit @unit
+                          :on-unit-change #(reset! unit %)}])]])))
 
 ;; ============================================================================
 ;; Mount

--- a/src/scittle/weather/current_conditions.cljs
+++ b/src/scittle/weather/current_conditions.cljs
@@ -6,6 +6,52 @@
             [clojure.string :as str]))
 
 ;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
+;; ============================================================================
 ;; API Functions (Inline from weather_api.cljs)
 ;; ============================================================================
 
@@ -53,12 +99,14 @@
 ;; Temperature Conversion Utilities
 ;; ============================================================================
 
-(defn celsius-to-fahrenheit [c]
+(defn celsius-to-fahrenheit
   "Convert Celsius to Fahrenheit"
+  [c]
   (when c (+ (* c 1.8) 32)))
 
-(defn celsius-to-kelvin [c]
+(defn celsius-to-kelvin
   "Convert Celsius to Kelvin"
+  [c]
   (when c (+ c 273.15)))
 
 (defn format-temp
@@ -84,12 +132,14 @@
           index (mod (Math/round (/ degrees 22.5)) 16)]
       (nth directions index))))
 
-(defn meters-to-miles [m]
+(defn meters-to-miles
   "Convert meters to miles"
+  [m]
   (when m (* m 0.000621371)))
 
-(defn mps-to-mph [mps]
+(defn mps-to-mph
   "Convert meters per second to miles per hour"
+  [mps]
   (when mps (* mps 2.237)))
 
 ;; ============================================================================
@@ -103,12 +153,13 @@
    :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"})
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "12px"
    :padding "24px"
    :margin-bottom "20px"
-   :box-shadow "0 2px 8px rgba(0,0,0,0.1)"})
+   :box-shadow "0 2px 8px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def header-style
   {:text-align "center"
@@ -117,12 +168,12 @@
 (def title-style
   {:font-size "28px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 10px 0"})
 
 (def subtitle-style
   {:font-size "14px"
-   :color "#666"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin 0})
 
 (def input-group-style
@@ -133,11 +184,14 @@
 
 (def input-style
   {:padding "10px 15px"
-   :border "1px solid #ddd"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :font-size "14px"
    :flex "1"
-   :min-width "120px"})
+   :min-width "120px"
+   :box-shadow "inset 0 1px 2px var(--shadow-color, rgba(0,0,0,0.05))"})
 
 (def button-style
   {:padding "10px 20px"
@@ -161,12 +215,15 @@
 
 (def quick-button-style
   {:padding "8px 16px"
-   :background "#f3f4f6"
-   :border "1px solid #e5e7eb"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :cursor "pointer"
    :font-size "13px"
-   :transition "all 0.2s"})
+   :font-weight "500"
+   :transition "all 0.2s"
+   :box-shadow "0 1px 2px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def temp-display-style
   {:text-align "center"
@@ -176,13 +233,13 @@
 (def large-temp-style
   {:font-size "72px"
    :font-weight "300"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0"
    :line-height "1"})
 
 (def condition-text-style
   {:font-size "20px"
-   :color "#4b5563"
+   :color "var(--text-secondary, #6b7280)"
    :margin "10px 0 20px 0"})
 
 (def unit-toggle-style
@@ -193,9 +250,10 @@
 
 (def unit-button-style
   {:padding "6px 16px"
-   :border "1px solid #ddd"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
-   :background "#fff"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
    :cursor "pointer"
    :font-size "14px"
    :transition "all 0.2s"})
@@ -214,13 +272,13 @@
 
 (def metric-card-style
   {:padding "15px"
-   :background "#f9fafb"
+   :background "var(--card-secondary-bg, #f9fafb)"
    :border-radius "8px"
-   :border "1px solid #e5e7eb"})
+   :border "1px solid var(--border-color, #e5e7eb)"})
 
 (def metric-label-style
   {:font-size "13px"
-   :color "#6b7280"
+   :color "#9ca3af"
    :margin "0 0 5px 0"
    :font-weight "500"
    :text-transform "uppercase"
@@ -228,7 +286,7 @@
 
 (def metric-value-style
   {:font-size "24px"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0"
    :font-weight "500"})
 
@@ -237,13 +295,13 @@
    :padding-top "20px"
    :border-top "1px solid #e0e0e0"
    :font-size "13px"
-   :color "#6b7280"
+   :color "#9ca3af"
    :text-align "center"})
 
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#6b7280"})
+   :color "#9ca3af"})
 
 (def error-style
   {:background "#fef2f2"
@@ -279,7 +337,8 @@
   [:div {:style error-style}
    [:strong "Error: "] message])
 
-(defn unit-toggle-buttons [{:keys [current-unit on-change]}]
+(defn unit-toggle-buttons
+  [{:keys [current-unit on-change]}]
   [:div {:style unit-toggle-style}
    (for [unit ["F" "C" "K"]]
      ^{:key unit}
@@ -290,12 +349,14 @@
        :on-click #(on-change unit)}
       unit])])
 
-(defn metric-card [{:keys [label value]}]
+(defn metric-card
+  [{:keys [label value]}]
   [:div {:style metric-card-style}
    [:div {:style metric-label-style} label]
    [:div {:style metric-value-style} (or value "—")]])
 
-(defn temperature-display [{:keys [temp-c unit condition]}]
+(defn temperature-display
+  [{:keys [temp-c unit condition]}]
   [:div {:style temp-display-style}
    [:div {:style large-temp-style}
     (format-temp temp-c unit)]
@@ -351,7 +412,8 @@
         {:label "Wind Chill"
          :value (format-temp wind-chill-c unit)}])]))
 
-(defn station-info [{:keys [observations]}]
+(defn station-info
+  [{:keys [observations]}]
   (let [props (:properties observations)
         station (:station props)
         timestamp (:timestamp props)
@@ -362,7 +424,8 @@
       (when timestamp
         (.toLocaleString (js/Date. timestamp)))]]))
 
-(defn weather-display [{:keys [observations unit on-unit-change]}]
+(defn weather-display
+  [{:keys [observations unit on-unit-change]}]
   (let [props (:properties observations)
         temp-c (:value (:temperature props))
         condition (:textDescription props)]
@@ -383,7 +446,12 @@
      [station-info
       {:observations observations}]]))
 
-(defn location-input [{:keys [lat lon on-lat-change on-lon-change on-fetch]}]
+(defn location-input
+  [{:keys [lat
+           lon
+           on-lat-change
+           on-lon-change
+           on-fetch]}]
   [:div
    [:div {:style input-group-style}
     [:input {:type "number"
@@ -404,15 +472,14 @@
               :on-mouse-out #(set! (.. % -target -style -background) "#3b82f6")}
      "Get Conditions"]]])
 
-(defn quick-city-buttons [{:keys [cities on-select]}]
+(defn quick-city-buttons
+  [{:keys [cities on-select]}]
   [:div {:style quick-buttons-style}
    (for [city cities]
      ^{:key (:name city)}
      [:button
       {:style quick-button-style
-       :on-click #(on-select city)
-       :on-mouse-over #(set! (.. % -target -style -background) "#e5e7eb")
-       :on-mouse-out #(set! (.. % -target -style -background) "#f3f4f6")}
+       :on-click #(on-select city)}
       (:name city)])])
 
 ;; ============================================================================
@@ -460,31 +527,33 @@
           (fetch-conditions))]
 
     (fn []
-      [:div {:style container-style}
-       [:div {:style header-style}
-        [:h1 {:style title-style} "☀️ Current Weather Conditions"]
-        [:p {:style subtitle-style}
-         "Detailed weather metrics from NOAA National Weather Service"]]
+      [:div
+       [theme-styles]
+       [:div {:style container-style}
+        [:div {:style header-style}
+         [:h1 {:style title-style} "☀️ Current Weather Conditions"]
+         [:p {:style subtitle-style}
+          "Detailed weather metrics from NOAA National Weather Service"]]
 
-       [:div {:style card-style}
-        [location-input
-         {:lat @lat
-          :lon @lon
-          :on-lat-change #(reset! lat %)
-          :on-lon-change #(reset! lon %)
-          :on-fetch fetch-conditions}]
+        [:div {:style card-style}
+         [location-input
+          {:lat @lat
+           :lon @lon
+           :on-lat-change #(reset! lat %)
+           :on-lon-change #(reset! lon %)
+           :on-fetch fetch-conditions}]
 
-        [quick-city-buttons
-         {:cities quick-cities
-          :on-select select-city}]]
+         [quick-city-buttons
+          {:cities quick-cities
+           :on-select select-city}]]
 
-       (cond
-         @loading? [loading-spinner]
-         @error [error-message {:message @error}]
-         @observations [weather-display
-                        {:observations @observations
-                         :unit @unit
-                         :on-unit-change #(reset! unit %)}])])))
+        (cond
+          @loading? [loading-spinner]
+          @error [error-message {:message @error}]
+          @observations [weather-display
+                         {:observations @observations
+                          :unit @unit
+                          :on-unit-change #(reset! unit %)}])]])))
 
 ;; ============================================================================
 ;; Mount

--- a/src/scittle/weather/forecast_viewer.cljs
+++ b/src/scittle/weather/forecast_viewer.cljs
@@ -6,6 +6,52 @@
             [clojure.string :as str]))
 
 ;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
+;; ============================================================================
 ;; API Functions (Inline)
 ;; ============================================================================
 
@@ -64,12 +110,14 @@
 ;; Temperature Conversion
 ;; ============================================================================
 
-(defn fahrenheit-to-celsius [f]
+(defn fahrenheit-to-celsius
   "Convert Fahrenheit to Celsius"
+  [f]
   (when f (* (- f 32) 0.5556)))
 
-(defn fahrenheit-to-kelvin [f]
+(defn fahrenheit-to-kelvin
   "Convert Fahrenheit to Kelvin"
+  [f]
   (when f (+ (fahrenheit-to-celsius f) 273.15)))
 
 (defn format-temp
@@ -93,8 +141,9 @@
    :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"})
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "12px"
    :padding "24px"
    :margin-bottom "20px"
@@ -107,12 +156,12 @@
 (def title-style
   {:font-size "28px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 10px 0"})
 
 (def subtitle-style
   {:font-size "14px"
-   :color "#666"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin 0})
 
 (def input-group-style
@@ -123,11 +172,14 @@
 
 (def input-style
   {:padding "10px 15px"
-   :border "1px solid #ddd"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :font-size "14px"
    :flex "1"
-   :min-width "120px"})
+   :min-width "120px"
+   :box-shadow "inset 0 1px 2px var(--shadow-color, rgba(0,0,0,0.05))"})
 
 (def button-style
   {:padding "10px 20px"
@@ -138,7 +190,8 @@
    :cursor "pointer"
    :font-size "14px"
    :font-weight "500"
-   :transition "background 0.2s"})
+   :transition "background 0.2s"
+   :box-shadow "0 2px 4px rgba(0,0,0,0.3)"})
 
 (def quick-buttons-style
   {:display "flex"
@@ -148,12 +201,15 @@
 
 (def quick-button-style
   {:padding "8px 16px"
-   :background "#f3f4f6"
-   :border "1px solid #e5e7eb"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :cursor "pointer"
    :font-size "13px"
-   :transition "all 0.2s"})
+   :font-weight "500"
+   :transition "all 0.2s"
+   :box-shadow "0 1px 2px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def controls-bar-style
   {:display "flex"
@@ -169,9 +225,10 @@
 
 (def toggle-button-style
   {:padding "8px 16px"
-   :border "1px solid #ddd"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
-   :background "#fff"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
    :cursor "pointer"
    :font-size "14px"
    :transition "all 0.2s"})
@@ -189,13 +246,13 @@
    :margin-top "20px"})
 
 (def forecast-card-style
-  {:background "#ffffff"
-   :border "1px solid #e5e7eb"
+  {:background "var(--card-secondary-bg, #f9fafb)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "10px"
    :padding "20px"
    :text-align "center"
    :transition "all 0.2s"
-   :box-shadow "0 1px 3px rgba(0,0,0,0.1)"})
+   :box-shadow "0 1px 3px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def forecast-card-hover-style
   (merge forecast-card-style
@@ -205,7 +262,7 @@
 (def period-name-style
   {:font-size "16px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 10px 0"})
 
 (def weather-icon-style
@@ -220,13 +277,13 @@
 
 (def forecast-text-style
   {:font-size "14px"
-   :color "#4b5563"
+   :color "var(--text-secondary, #6b7280)"
    :margin "10px 0 5px 0"
    :line-height "1.4"})
 
 (def wind-style
   {:font-size "13px"
-   :color "#6b7280"
+   :color "#9ca3af"
    :margin "5px 0"})
 
 (def precip-style
@@ -238,7 +295,7 @@
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#6b7280"})
+   :color "#9ca3af"})
 
 (def error-style
   {:background "#fef2f2"
@@ -251,7 +308,7 @@
 (def location-display-style
   {:font-size "18px"
    :font-weight "500"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin-bottom "10px"})
 
 ;; ============================================================================
@@ -276,11 +333,13 @@
    [:div {:style {:font-size "40px" :margin-bottom "10px"}} "⏳"]
    [:div "Loading forecast data..."]])
 
-(defn error-message [{:keys [message]}]
+(defn error-message
+  [{:keys [message]}]
   [:div {:style error-style}
    [:strong "Error: "] message])
 
-(defn location-input [{:keys [lat lon on-lat-change on-lon-change on-fetch]}]
+(defn location-input
+  [{:keys [lat lon on-lat-change on-lon-change on-fetch]}]
   [:div
    [:div {:style input-group-style}
     [:input {:type "number"
@@ -301,18 +360,21 @@
               :on-mouse-out #(set! (.. % -target -style -background) "#3b82f6")}
      "Get Forecast"]]])
 
-(defn quick-city-buttons [{:keys [cities on-select]}]
+(defn quick-city-buttons
+  [{:keys [cities on-select]}]
   [:div {:style quick-buttons-style}
    (for [city cities]
      ^{:key (:name city)}
      [:button
       {:style quick-button-style
-       :on-click #(on-select city)
-       :on-mouse-over #(set! (.. % -target -style -background) "#e5e7eb")
-       :on-mouse-out #(set! (.. % -target -style -background) "#f3f4f6")}
+       :on-click #(on-select city)}
       (:name city)])])
 
-(defn controls-bar [{:keys [show-all? on-toggle-periods unit on-unit-change]}]
+(defn controls-bar
+  [{:keys [show-all?
+           on-toggle-periods
+           unit
+           on-unit-change]}]
   [:div {:style controls-bar-style}
    [:div {:style toggle-group-style}
     [:button
@@ -332,7 +394,8 @@
         :on-click #(on-unit-change u)}
        u])]])
 
-(defn forecast-card [{:keys [period unit]}]
+(defn forecast-card
+  [{:keys [period unit]}]
   (let [hovering? (r/atom false)]
     (fn [{:keys [period unit]}]
       (let [{:keys [name temperature windSpeed windDirection
@@ -357,14 +420,21 @@
            [:div {:style precip-style}
             "💧 " precip-value "% chance"])]))))
 
-(defn forecast-grid [{:keys [periods unit show-all?]}]
+(defn forecast-grid
+  [{:keys [periods unit show-all?]}]
   (let [displayed-periods (if show-all? periods (take 7 periods))]
     [:div {:style forecast-grid-style}
      (for [period displayed-periods]
        ^{:key (:number period)}
        [forecast-card {:period period :unit unit}])]))
 
-(defn forecast-display [{:keys [forecast-data location-name unit show-all? on-toggle-periods on-unit-change]}]
+(defn forecast-display
+  [{:keys [forecast-data
+           location-name
+           unit
+           show-all?
+           on-toggle-periods
+           on-unit-change]}]
   (let [periods (get-in forecast-data [:properties :periods])]
     [:div
      [:div {:style location-display-style} "📍 " location-name]
@@ -384,7 +454,8 @@
 ;; Main Component
 ;; ============================================================================
 
-(defn main-component []
+(defn main-component
+  []
   (let [lat (r/atom "35.2271")
         lon (r/atom "-80.8431")
         location-name (r/atom "Charlotte, NC")

--- a/src/scittle/weather/hourly_forecast.cljs
+++ b/src/scittle/weather/hourly_forecast.cljs
@@ -6,6 +6,52 @@
             [clojure.string :as str]))
 
 ;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
+;; ============================================================================
 ;; API Functions (Inline)
 ;; ============================================================================
 
@@ -103,12 +149,14 @@
 ;; Temperature Conversion
 ;; ============================================================================
 
-(defn fahrenheit-to-celsius [f]
+(defn fahrenheit-to-celsius
   "Convert Fahrenheit to Celsius"
+  [f]
   (when f (* (- f 32) 0.5556)))
 
-(defn fahrenheit-to-kelvin [f]
+(defn fahrenheit-to-kelvin
   "Convert Fahrenheit to Kelvin"
+  [f]
   (when f (+ (fahrenheit-to-celsius f) 273.15)))
 
 (defn format-temp
@@ -121,8 +169,9 @@
       "K" (str (Math/round (fahrenheit-to-kelvin fahrenheit)) "K")
       (str fahrenheit "°F"))))
 
-(defn mps-to-mph [mps]
+(defn mps-to-mph
   "Convert meters per second to miles per hour"
+  [mps]
   (when mps (* mps 2.237)))
 
 ;; ============================================================================
@@ -136,12 +185,13 @@
    :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"})
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "12px"
    :padding "24px"
    :margin-bottom "20px"
-   :box-shadow "0 2px 8px rgba(0,0,0,0.1)"})
+   :box-shadow "0 2px 8px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def header-style
   {:text-align "center"
@@ -150,12 +200,12 @@
 (def title-style
   {:font-size "28px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 10px 0"})
 
 (def subtitle-style
   {:font-size "14px"
-   :color "#666"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin 0})
 
 (def input-group-style
@@ -166,11 +216,13 @@
 
 (def input-style
   {:padding "10px 15px"
-   :border "1px solid #ddd"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :font-size "14px"
    :flex "1"
-   :min-width "120px"})
+   :min-width "120px"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"})
 
 (def button-style
   {:padding "10px 20px"
@@ -191,8 +243,9 @@
 
 (def quick-button-style
   {:padding "8px 16px"
-   :background "#f3f4f6"
-   :border "1px solid #e5e7eb"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :cursor "pointer"
    :font-size "13px"
@@ -214,13 +267,14 @@
 (def slider-label-style
   {:font-size "14px"
    :font-weight "500"
-   :color "#4b5563"})
+   :color "var(--text-secondary, #6b7280)"})
 
 (def slider-button-style
   {:padding "6px 14px"
-   :border "1px solid #ddd"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
-   :background "#fff"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
    :cursor "pointer"
    :font-size "13px"
    :transition "all 0.2s"})
@@ -237,9 +291,10 @@
 
 (def unit-button-style
   {:padding "6px 14px"
-   :border "1px solid #ddd"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
-   :background "#fff"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
    :cursor "pointer"
    :font-size "13px"
    :transition "all 0.2s"})
@@ -264,15 +319,15 @@
    :padding "5px"})
 
 (def hour-card-style
-  {:background "#ffffff"
-   :border "1px solid #e5e7eb"
+  {:background "var(--card-secondary-bg, #f9fafb)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "10px"
    :padding "16px"
    :min-width "140px"
    :text-align "center"
    :flex-shrink "0"
    :transition "all 0.2s"
-   :box-shadow "0 1px 3px rgba(0,0,0,0.1)"})
+   :box-shadow "0 1px 3px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def hour-card-current-style
   (merge hour-card-style
@@ -288,7 +343,7 @@
 (def time-label-style
   {:font-size "14px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 8px 0"})
 
 (def weather-icon-style
@@ -308,13 +363,13 @@
 
 (def wind-display-style
   {:font-size "12px"
-   :color "#6b7280"
+   :color "#9ca3af"
    :margin "4px 0"})
 
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#6b7280"})
+   :color "#9ca3af"})
 
 (def error-style
   {:background "#fef2f2"
@@ -327,7 +382,7 @@
 (def location-display-style
   {:font-size "18px"
    :font-weight "500"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin-bottom "15px"})
 
 ;; ============================================================================
@@ -347,7 +402,8 @@
 ;; Components
 ;; ============================================================================
 
-(defn loading-spinner []
+(defn loading-spinner
+  []
   [:div {:style loading-style}
    [:div {:style {:font-size "40px" :margin-bottom "10px"}} "⏳"]
    [:div "Loading hourly forecast..."]])
@@ -356,7 +412,8 @@
   [:div {:style error-style}
    [:strong "Error: "] message])
 
-(defn location-input [{:keys [lat lon on-lat-change on-lon-change on-fetch]}]
+(defn location-input
+  [{:keys [lat lon on-lat-change on-lon-change on-fetch]}]
   [:div
    [:div {:style input-group-style}
     [:input {:type "number"
@@ -372,23 +429,21 @@
              :step "0.0001"
              :style input-style}]
     [:button {:on-click on-fetch
-              :style button-style
-              :on-mouse-over #(set! (.. % -target -style -background) "#2563eb")
-              :on-mouse-out #(set! (.. % -target -style -background) "#3b82f6")}
+              :style button-style}
      "Get Hourly Forecast"]]])
 
-(defn quick-city-buttons [{:keys [cities on-select]}]
+(defn quick-city-buttons
+  [{:keys [cities on-select]}]
   [:div {:style quick-buttons-style}
    (for [city cities]
      ^{:key (:name city)}
      [:button
       {:style quick-button-style
-       :on-click #(on-select city)
-       :on-mouse-over #(set! (.. % -target -style -background) "#e5e7eb")
-       :on-mouse-out #(set! (.. % -target -style -background) "#f3f4f6")}
+       :on-click #(on-select city)}
       (:name city)])])
 
-(defn controls-bar [{:keys [hours-to-show on-hours-change unit on-unit-change]}]
+(defn controls-bar
+  [{:keys [hours-to-show on-hours-change unit on-unit-change]}]
   [:div {:style controls-bar-style}
    [:div {:style slider-group-style}
     [:span {:style slider-label-style} "Show:"]
@@ -409,39 +464,35 @@
         :on-click #(on-unit-change u)}
        u])]])
 
-(defn hour-card [{:keys [period unit]}]
-  (let [hovering? (r/atom false)]
-    (fn [{:keys [period unit]}]
-      (let [{:keys [startTime temperature windSpeed shortForecast
-                    probabilityOfPrecipitation]} period
-            date (parse-iso-time startTime)
-            is-current? (is-current-hour? date)
-            precip-value (get-in probabilityOfPrecipitation [:value])
-            icon (get-weather-icon shortForecast)
-            wind-mph (when windSpeed
-                       (let [wind-str (str windSpeed)
-                             matches (re-find #"(\d+)" wind-str)]
-                         (when matches (js/parseInt (second matches)))))]
-        [:div
-         {:style (cond
-                   is-current? hour-card-current-style
-                   @hovering? hour-card-hover-style
-                   :else hour-card-style)
-          :on-mouse-enter #(reset! hovering? true)
-          :on-mouse-leave #(reset! hovering? false)}
+(defn hour-card
+  [{:keys [period unit]}]
+  (let [{:keys [startTime temperature windSpeed shortForecast
+                probabilityOfPrecipitation]} period
+        date (parse-iso-time startTime)
+        is-current? (is-current-hour? date)
+        precip-value (get-in probabilityOfPrecipitation [:value])
+        icon (get-weather-icon shortForecast)
+        wind-mph (when windSpeed
+                   (let [wind-str (str windSpeed)
+                         matches (re-find #"(\d+)" wind-str)]
+                     (when matches (js/parseInt (second matches)))))]
+    [:div
+     {:style (if is-current?
+               hour-card-current-style
+               hour-card-style)}
 
-         [:div {:style time-label-style}
-          (if is-current? "🔵 Now" (format-hour-time date))]
-         [:div {:style weather-icon-style} icon]
-         [:div {:style temp-display-style} (format-temp temperature unit)]
+     [:div {:style time-label-style}
+      (if is-current? "🔵 Now" (format-hour-time date))]
+     [:div {:style weather-icon-style} icon]
+     [:div {:style temp-display-style} (format-temp temperature unit)]
 
-         (when (and precip-value (> precip-value 0))
-           [:div {:style precip-display-style}
-            "💧 " precip-value "%"])
+     (when (and precip-value (> precip-value 0))
+       [:div {:style precip-display-style}
+        "💧 " precip-value "%"])
 
-         (when wind-mph
-           [:div {:style wind-display-style}
-            "💨 " wind-mph " mph"])]))))
+     (when wind-mph
+       [:div {:style wind-display-style}
+        "💨 " wind-mph " mph"])]))
 
 (defn hourly-timeline [{:keys [periods unit hours-to-show timeline-ref]}]
   (let [displayed-periods (take hours-to-show periods)]
@@ -452,8 +503,14 @@
         ^{:key (:number period)}
         [hour-card {:period period :unit unit}])]]))
 
-(defn forecast-display [{:keys [forecast-data location-name unit hours-to-show
-                                on-hours-change on-unit-change timeline-ref]}]
+(defn forecast-display
+  [{:keys [forecast-data
+           location-name
+           unit
+           hours-to-show
+           on-hours-change
+           on-unit-change
+           timeline-ref]}]
   (let [periods (get-in forecast-data [:properties :periods])]
     [:div
      [:div {:style location-display-style} "📍 " location-name]
@@ -527,11 +584,13 @@
           (fetch-forecast))]
 
     (fn []
-      [:div {:style container-style}
-       [:div {:style header-style}
-        [:h1 {:style title-style} "⏰ Hourly Weather Forecast"]
-        [:p {:style subtitle-style}
-         "Hour-by-hour predictions with interactive timeline"]]
+      [:<>
+       [theme-styles]
+       [:div {:style container-style}
+        [:div {:style header-style}
+         [:h1 {:style title-style} "⏰ Hourly Weather Forecast"]
+         [:p {:style subtitle-style}
+          "Hour-by-hour predictions with interactive timeline"]]]
 
        [:div {:style card-style}
         [location-input

--- a/src/scittle/weather/simple_lookup.cljs
+++ b/src/scittle/weather/simple_lookup.cljs
@@ -19,6 +19,52 @@
 ;; Inline API Functions (simplified for this demo)
 ;; ============================================================================
 
+;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+    
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
 (defn fetch-json
   "Fetch JSON from URL with error handling."
   [{:keys [url on-success on-error]}]
@@ -68,20 +114,23 @@
 ;; ============================================================================
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "8px"
    :padding "20px"
-   :box-shadow "0 2px 4px rgba(0,0,0,0.1)"
+   :box-shadow "0 2px 4px var(--shadow-color, rgba(0,0,0,0.1))"
    :margin-bottom "20px"})
 
 (def input-style
   {:width "100%"
    :padding "10px"
-   :border "1px solid #ddd"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "4px"
    :font-size "14px"
-   :margin-bottom "10px"})
+   :margin-bottom "10px"
+   :box-shadow "inset 0 1px 2px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def button-style
   {:background "#2196f3"
@@ -91,17 +140,21 @@
    :border-radius "4px"
    :cursor "pointer"
    :font-size "16px"
+   :font-weight "500"
    :width "100%"
-   :transition "background 0.3s"})
+   :transition "background 0.3s, transform 0.1s"
+   :box-shadow "0 2px 4px rgba(0,0,0,0.1)"})
 
 (def button-hover-style
   (merge button-style
-         {:background "#1976d2"}))
+         {:background "#1976d2"
+          :box-shadow "0 4px 8px rgba(0,0,0,0.15)"}))
 
 (def button-disabled-style
   (merge button-style
          {:background "#ccc"
-          :cursor "not-allowed"}))
+          :cursor "not-allowed"
+          :box-shadow "none"}))
 
 ;; ============================================================================
 ;; Components
@@ -121,7 +174,7 @@
                   :animation "spin 1s linear infinite"}}]
    [:style "@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }"]
    [:p {:style {:margin-top "15px"
-                :color "#666"}}
+                :color "var(--text-tertiary, #9ca3af)"}}
     "Fetching weather data..."]])
 
 (defn error-display
@@ -133,7 +186,7 @@
    [:h4 {:style {:margin-top 0
                  :color "#c62828"}}
     "⚠️ Error"]
-   [:p {:style {:color "#666"}}
+   [:p {:style {:color "var(--text-tertiary, #9ca3af)"}}
     error]
    (when on-retry
      [:button {:on-click on-retry
@@ -158,20 +211,20 @@
                   :margin "30px 0"}}
     [:div {:style {:font-size "48px"
                    :font-weight "bold"
-                   :color "#333"}}
+                   :color "var(--text-primary, #1f2937)"}}
      (:temperature data) "°" (:temperatureUnit data)]
     [:div {:style {:font-size "18px"
-                   :color "#666"
+                   :color "var(--text-tertiary, #9ca3af)"
                    :margin-top "10px"}}
      (:shortForecast data)]]
 
-   [:div {:style {:background "#f5f5f5"
+   [:div {:style {:background "var(--card-secondary-bg, #f9fafb)"
                   :padding "15px"
                   :border-radius "4px"
                   :margin-top "20px"}}
     [:p {:style {:margin 0
                  :line-height 1.6
-                 :color "#555"}}
+                 :color "var(--text-secondary, #6b7280)"}}
      (:detailedForecast data)]]])
 
 (defn input-form
@@ -180,7 +233,7 @@
   [:div {:style card-style}
    [:h3 {:style {:margin-top 0}}
     "🌍 Enter Coordinates"]
-   [:p {:style {:color "#666"
+   [:p {:style {:color "var(--text-tertiary, #9ca3af)"
                 :font-size "14px"
                 :margin-bottom "15px"}}
     "Enter latitude and longitude to get weather data"]
@@ -188,7 +241,7 @@
    [:div
     [:label {:style {:display "block"
                      :margin-bottom "5px"
-                     :color "#555"
+                     :color "var(--text-secondary, #6b7280)"
                      :font-weight "500"}}
      "Latitude"]
     [:input {:type "number"
@@ -203,7 +256,7 @@
    [:div
     [:label {:style {:display "block"
                      :margin-bottom "5px"
-                     :color "#555"
+                     :color "var(--text-secondary, #6b7280)"
                      :font-weight "500"}}
      "Longitude"]
     [:input {:type "number"
@@ -229,7 +282,7 @@
   "Quick access buttons for major cities."
   [{:keys [on-select loading?]}]
   [:div {:style {:margin-top "20px"}}
-   [:p {:style {:color "#666"
+   [:p {:style {:color "var(--text-tertiary, #9ca3af)"
                 :font-size "14px"
                 :margin-bottom "10px"}}
     "Or try these cities:"]
@@ -246,13 +299,15 @@
       [:button {:on-click #(on-select lat lon)
                 :disabled loading?
                 :style {:padding "6px 12px"
-                        :background (if loading? "#ccc" "transparent")
-                        :color (if loading? "#999" "#2196f3")
-                        :border "1px solid #2196f3"
+                        :background (if loading? "var(--button-bg, #f3f4f6)" "var(--button-bg, #f3f4f6)")
+                        :color (if loading? "var(--text-tertiary, #9ca3af)" "#60a5fa")
+                        :border (if loading? "1px solid var(--border-color, #e5e7eb)" "2px solid #60a5fa")
                         :border-radius "20px"
                         :cursor (if loading? "not-allowed" "pointer")
                         :font-size "13px"
-                        :transition "all 0.2s"}}
+                        :font-weight "500"
+                        :transition "all 0.2s"
+                        :box-shadow (when-not loading? "0 1px 3px var(--shadow-color, rgba(0,0,0,0.1))")}}
        city])]])
 
 ;; ============================================================================
@@ -284,14 +339,16 @@
                                       (reset! error err))}))]
 
     (fn []
-      [:div {:style {:max-width "600px"
-                     :margin "0 auto"
-                     :padding "20px"
-                     :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"}}
-       [:h1 {:style {:text-align "center"
-                     :color "#333"
-                     :margin-bottom "30px"}}
-        "☀️ Simple Weather Lookup"]
+      [:<>
+       [theme-styles]
+       [:div {:style {:max-width "600px"
+                      :margin "0 auto"
+                      :padding "20px"
+                      :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"}}
+        [:h1 {:style {:text-align "center"
+                      :color "var(--text-primary, #1f2937)"
+                      :margin-bottom "30px"}}
+         "☀️ Simple Weather Lookup"]]
 
        ;; Input Form
        [input-form
@@ -336,7 +393,7 @@
                   (not @weather-data))
          [:div {:style {:text-align "center"
                         :margin-top "40px"
-                        :color "#999"
+                        :color "var(--text-tertiary, #9ca3af)"
                         :font-size "14px"}}
           [:p "Enter coordinates above or click a city to get started"]
           [:p {:style {:margin-top "10px"}}

--- a/src/scittle/weather/weather_alerts.cljs
+++ b/src/scittle/weather/weather_alerts.cljs
@@ -34,6 +34,52 @@
 ;; Severity Utilities
 ;; ============================================================================
 
+;; ============================================================================
+;; Theme Styles
+;; ============================================================================
+
+(defn theme-styles
+  "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
+  []
+  [:style "
+    /* Light mode (default) */
+    [data-bs-theme='light'] {
+      --card-bg: #ffffff;
+      --card-secondary-bg: #f9fafb;
+      --input-bg: #ffffff;
+      --text-primary: #1f2937;
+      --text-secondary: #6b7280;
+      --text-tertiary: #9ca3af;
+      --border-color: #e5e7eb;
+      --border-color-dark: #d1d5db;
+      --button-bg: #f3f4f6;
+      --button-hover: #e5e7eb;
+      --button-text: #374151;
+      --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    /* Dark mode */
+    [data-bs-theme='dark'] {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Hover states - applied universally */
+    button:not(.btn-primary):hover {
+      background: var(--button-hover) !important;
+    }
+  "])
+
 (defn get-severity-color
   "Map severity level to color."
   [severity]
@@ -104,12 +150,13 @@
    :font-family "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"})
 
 (def card-style
-  {:background "#ffffff"
-   :border "1px solid #e0e0e0"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "12px"
    :padding "24px"
    :margin-bottom "20px"
-   :box-shadow "0 2px 8px rgba(0,0,0,0.1)"})
+   :box-shadow "0 2px 8px var(--shadow-color, rgba(0,0,0,0.1))"})
 
 (def header-style
   {:text-align "center"
@@ -118,12 +165,12 @@
 (def title-style
   {:font-size "28px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 10px 0"})
 
 (def subtitle-style
   {:font-size "14px"
-   :color "#666"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin 0})
 
 (def input-group-style
@@ -134,7 +181,9 @@
 
 (def input-style
   {:padding "10px 15px"
-   :border "1px solid #ddd"
+   :background "var(--input-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :font-size "14px"
    :flex "1"
@@ -159,8 +208,9 @@
 
 (def quick-button-style
   {:padding "8px 16px"
-   :background "#f3f4f6"
-   :border "1px solid #e5e7eb"
+   :background "var(--button-bg, #f3f4f6)"
+   :color "var(--button-text, #374151)"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :cursor "pointer"
    :font-size "13px"
@@ -172,11 +222,12 @@
    :gap "15px"})
 
 (defn alert-card-style [severity-color]
-  {:background "#ffffff"
+  {:background "var(--card-bg, #ffffff)"
+   :color "var(--text-primary, #1f2937)"
    :border-left (str "4px solid " severity-color)
    :border-radius "8px"
    :padding "20px"
-   :box-shadow "0 2px 6px rgba(0,0,0,0.1)"
+   :box-shadow "0 2px 6px var(--shadow-color, rgba(0,0,0,0.1))"
    :transition "all 0.2s"})
 
 (def alert-header-style
@@ -192,7 +243,7 @@
 (def alert-event-style
   {:font-size "20px"
    :font-weight "600"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 8px 0"
    :display "flex"
    :align-items "center"
@@ -200,7 +251,7 @@
 
 (def alert-headline-style
   {:font-size "14px"
-   :color "#4b5563"
+   :color "var(--text-secondary, #6b7280)"
    :margin "0 0 12px 0"
    :line-height "1.4"})
 
@@ -222,12 +273,12 @@
 
 (def expand-button-style
   {:background "transparent"
-   :border "1px solid #d1d5db"
+   :border "1px solid var(--border-color-dark, #d1d5db)"
    :border-radius "6px"
    :padding "8px 16px"
    :cursor "pointer"
    :font-size "13px"
-   :color "#4b5563"
+   :color "var(--text-secondary, #6b7280)"
    :transition "all 0.2s"
    :display "flex"
    :align-items "center"
@@ -236,11 +287,11 @@
 (def expanded-details-style
   {:margin-top "15px"
    :padding-top "15px"
-   :border-top "1px solid #e5e7eb"})
+   :border-top "1px solid var(--border-color, #e5e7eb)"})
 
 (def description-style
   {:font-size "14px"
-   :color "#374151"
+   :color "var(--text-secondary, #6b7280)"
    :line-height "1.6"
    :margin "0 0 15px 0"
    :white-space "pre-wrap"})
@@ -251,21 +302,22 @@
    :gap "10px"
    :margin-top "15px"
    :padding "12px"
-   :background "#f9fafb"
+   :background "var(--card-secondary-bg, #f9fafb)"
+   :border "1px solid var(--border-color, #e5e7eb)"
    :border-radius "6px"})
 
 (def time-item-style
   {:font-size "13px"
-   :color "#6b7280"})
+   :color "var(--text-secondary, #6b7280)"})
 
 (def time-label-style
   {:font-weight "600"
-   :color "#374151"})
+   :color "var(--text-primary, #1f2937)"})
 
 (def no-alerts-style
   {:text-align "center"
    :padding "40px"
-   :color "#6b7280"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def no-alerts-icon-style
   {:font-size "64px"
@@ -274,17 +326,17 @@
 (def no-alerts-text-style
   {:font-size "18px"
    :font-weight "500"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin "0 0 8px 0"})
 
 (def no-alerts-subtext-style
   {:font-size "14px"
-   :color "#6b7280"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#6b7280"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def error-style
   {:background "#fef2f2"
@@ -297,7 +349,7 @@
 (def location-display-style
   {:font-size "18px"
    :font-weight "500"
-   :color "#1a1a1a"
+   :color "var(--text-primary, #1f2937)"
    :margin-bottom "20px"})
 
 ;; ============================================================================
@@ -356,8 +408,8 @@
      [:button
       {:style quick-button-style
        :on-click #(on-select city)
-       :on-mouse-over #(set! (.. % -target -style -background) "#e5e7eb")
-       :on-mouse-out #(set! (.. % -target -style -background) "#f3f4f6")}
+       :on-mouse-over #(set! (.. % -target -style -background) "#4b5563")
+       :on-mouse-out #(set! (.. % -target -style -background) "#374151")}
       (:name city)])])
 
 (defn alert-card-component [{:keys [alert]}]
@@ -389,7 +441,7 @@
        [:button
         {:style expand-button-style
          :on-click #(swap! expanded? not)
-         :on-mouse-over #(set! (.. % -target -style -background) "#f3f4f6")
+         :on-mouse-over #(set! (.. % -target -style -background) "#374151")
          :on-mouse-out #(set! (.. % -target -style -background) "transparent")}
         [:span (if @expanded? "▼" "▶")]
         [:span (if @expanded? "Hide Details" "View Details")]]

--- a/src/scittle/weather/weather_api.cljs
+++ b/src/scittle/weather/weather_api.cljs
@@ -1,9 +1,9 @@
 (ns scittle.weather.weather-api
   "National Weather Service API integration with keyword arguments.
-   
+
    All functions use keyword argument maps for clarity and flexibility.
    No API key required - completely free!
-   
+
    Main API Reference: https://www.weather.gov/documentation/services-web-api"
   (:require [clojure.string :as str]))
 
@@ -21,17 +21,17 @@
 
 (defn fetch-json
   "Fetch JSON data from a URL with error handling.
-  
+
   Uses browser's native fetch API - no external dependencies.
-  
+
   Args (keyword map):
     :url        - URL to fetch (string, required)
     :on-success - Success callback receiving parsed data (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-    
+
   The success callback receives the parsed JSON as a Clojure map.
   The error callback receives an error message string.
-  
+
   Example:
     (fetch-json
       {:url \"https://api.weather.gov/points/40,-74\"
@@ -55,16 +55,16 @@
 
 (defn fetch-points
   "Get NWS grid points and forecast URLs for given coordinates.
-  
+
   This is typically the first API call - it returns URLs for all weather
   products available at the given location.
-  
+
   Args (keyword map):
     :lat        - Latitude (number, required, range: -90 to 90)
     :lon        - Longitude (number, required, range: -180 to 180)
     :on-success - Success callback receiving location data (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a map with:
     :forecast             - URL for 7-day forecast
     :forecastHourly       - URL for hourly forecast
@@ -74,7 +74,7 @@
     :gridId               - Grid identifier
     :gridX, :gridY        - Grid coordinates
     :city, :state         - Location name
-  
+
   Example:
     (fetch-points
       {:lat 40.7128
@@ -110,14 +110,14 @@
 
 (defn fetch-forecast
   "Fetch 7-day forecast from a forecast URL.
-  
+
   Returns periods (typically 14 periods: day/night for 7 days).
-  
+
   Args (keyword map):
     :url        - Forecast URL from points API (string, required)
     :on-success - Success callback receiving forecast periods (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a vector of period maps, each containing:
     :number              - Period number
     :name                - Period name (e.g., \"Tonight\", \"Friday\")
@@ -128,7 +128,7 @@
     :icon                - Weather icon URL
     :shortForecast       - Brief description
     :detailedForecast    - Detailed description
-  
+
   Example:
     (fetch-forecast
       {:url forecast-url
@@ -151,15 +151,15 @@
 
 (defn fetch-hourly-forecast
   "Fetch hourly forecast from a forecast URL.
-  
+
   Args (keyword map):
     :url        - Hourly forecast URL from points API (string, required)
     :on-success - Success callback receiving hourly periods (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a vector of hourly period maps.
   Each period has the same structure as the regular forecast.
-  
+
   Example:
     (fetch-hourly-forecast
       {:url hourly-url
@@ -183,17 +183,17 @@
 
 (defn fetch-observation-stations
   "Get list of observation stations near a location.
-  
+
   Args (keyword map):
     :url        - Observation stations URL from points API (string, required)
     :on-success - Success callback receiving station list (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a vector of station maps, each containing:
     :stationIdentifier - Station ID (e.g., \"KJFK\")
     :name              - Station name
     :elevation         - Elevation data
-  
+
   Example:
     (fetch-observation-stations
       {:url stations-url
@@ -221,12 +221,12 @@
 
 (defn fetch-current-observations
   "Get current weather observations from a station.
-  
+
   Args (keyword map):
     :station-id - Station identifier (string, required, e.g., \"KJFK\")
     :on-success - Success callback receiving observation data (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a map with current conditions:
     :temperature          - Current temperature with :value and :unitCode
     :dewpoint            - Dewpoint temperature
@@ -237,7 +237,7 @@
     :visibility          - Visibility distance
     :textDescription     - Weather description
     :timestamp           - Observation time
-  
+
   Example:
     (fetch-current-observations
       {:station-id \"KJFK\"
@@ -262,13 +262,13 @@
 
 (defn fetch-alerts-for-point
   "Fetch active weather alerts for a specific location.
-  
+
   Args (keyword map):
     :lat        - Latitude (number, required)
     :lon        - Longitude (number, required)
     :on-success - Success callback receiving alerts list (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a vector of alert maps, each containing:
     :event       - Alert type (e.g., \"Tornado Warning\")
     :headline    - Brief headline
@@ -278,7 +278,7 @@
     :certainty   - Certainty level
     :onset       - Start time
     :ends        - End time
-  
+
   Example:
     (fetch-alerts-for-point
       {:lat 40.7128
@@ -307,7 +307,7 @@
 
 (defn fetch-complete-weather
   "Fetch comprehensive weather data for given coordinates.
-  
+
   This is a convenience function that:
   1. Fetches points data
   2. Fetches 7-day forecast
@@ -315,15 +315,15 @@
   4. Fetches observation stations
   5. Fetches current observations from nearest station
   6. Fetches active alerts
-  
+
   All data is collected and returned in a single callback.
-  
+
   Args (keyword map):
     :lat        - Latitude (number, required)
     :lon        - Longitude (number, required)
     :on-success - Success callback receiving complete weather data (fn, required)
     :on-error   - Error callback receiving error message (fn, optional)
-  
+
   Success callback receives a map with:
     :points   - Location and grid information
     :forecast - 7-day forecast periods
@@ -331,13 +331,13 @@
     :stations - Nearby weather stations
     :current  - Current observations
     :alerts   - Active weather alerts
-  
+
   Example:
     (fetch-complete-weather
       {:lat 40.7128
        :lon -74.0060
        :on-success (fn [weather]
-                     (js/console.log \"Location:\" 
+                     (js/console.log \"Location:\"
                                      (get-in weather [:points :city]))
                      (js/console.log \"Current temp:\"
                                      (get-in weather [:current :temperature :value]))
@@ -401,13 +401,13 @@
 
 (defn get-weather-icon
   "Map NWS icon URLs to emoji representations.
-  
+
   Args:
     icon-url - NWS icon URL (string)
-  
+
   Returns:
     Emoji string representing the weather condition.
-  
+
   Example:
     (get-weather-icon \"https://api.weather.gov/icons/land/day/rain\")
     ;; => \"🌧️\""

--- a/src/scittle/weather/weather_nws_integration.clj
+++ b/src/scittle/weather/weather_nws_integration.clj
@@ -47,6 +47,7 @@
 ;; ### Free and Accessible
 
 ;; Most weather APIs require:
+;;
 ;; - Signing up for an account
 ;; - Managing API keys
 ;; - Dealing with rate limits
@@ -107,6 +108,7 @@
 ;; Use the returned URLs to fetch the specific weather data you need: forecasts, hourly predictions, current conditions, etc.
 
 ;; This design is smart because:
+;;
 ;; - Forecasts are generated for grid points, not exact coordinates
 ;; - It allows the API to scale efficiently
 ;; - You get all relevant endpoints in one initial request
@@ -150,6 +152,7 @@
 ;; - **Your browser** - That's it!
 
 ;; All demos will be embedded right in this article. You can:
+;;
 ;; - Run them immediately
 ;; - View the source code
 ;; - Copy and adapt for your own projects
@@ -395,11 +398,11 @@
     A --> C[Severe - Orange]
     A --> D[Moderate - Yellow]
     A --> E[Minor - Green]
-    
+
     F[Urgency] --> G[Immediate - Red]
     F --> H[Expected - Orange]
     F --> I[Future - Blue]
-    
+
     J[Certainty] --> K[Observed - Green]
     J --> L[Likely - Blue]
     J --> M[Possible - Purple]")


### PR DESCRIPTION
Implement comprehensive dark mode support using CSS variables that respond to Quarto's theme toggle. Update 6 weather components with automatic light/dark theme switching for backgrounds, text, and borders.

- Add theme-styles CSS injection to all weather components
- Replace JS hover handlers with CSS pseudo-classes
- Minor styling improvements to QR code scanner components
- Still more to be updated for light/dark background (TBD)