### PR TITLE
fix(weather): Fix dark mode CSS inheritance in weather components

### DIFF
--- a/src/scittle/weather/complete_dashboard.cljs
+++ b/src/scittle/weather/complete_dashboard.cljs
@@ -13,8 +13,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -29,8 +30,26 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -254,13 +273,13 @@
 (def tabs-container-style
   {:display "flex"
    :gap "5px"
-   :border-bottom "2px solid #374151"
+   :border-bottom "2px solid var(--border-color-dark, #4b5563)"
    :margin-bottom "20px"})
 
 (defn tab-style [active?]
   {:padding "12px 24px"
    :background (if active? "#3b82f6" "transparent")
-   :color (if active? "white" "#6b7280")
+   :color (if active? "white" "var(--text-secondary, #6b7280)")
    :border "none"
    :border-bottom (if active? "2px solid #3b82f6" "2px solid transparent")
    :cursor "pointer"
@@ -338,7 +357,7 @@
 
 (def metric-label-style
   {:font-size "12px"
-   :color "#9ca3af"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin-bottom "5px"
    :text-transform "uppercase"
    :font-weight "600"})
@@ -363,7 +382,7 @@
 (def loading-style
   {:text-align "center"
    :padding "60px"
-   :color "#9ca3af"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 ;; ============================================================================
 ;; Quick Cities
@@ -430,7 +449,7 @@
          :on-click #(on-unit-change u)}
         u])]]
 
-   [:div {:style {:font-size "13px" :color "#9ca3af"}}
+   [:div {:style {:font-size "13px" :color "var(--text-tertiary, #9ca3af)"}}
     "🔄 Auto-refresh: Off"]])
 
 (defn tabs-navigation [{:keys [active-tab on-tab-change]}]
@@ -491,7 +510,7 @@
          (get-weather-icon (:shortForecast period))]
         [:div {:style {:font-size "24px" :font-weight "600" :color "#3b82f6"}}
          (format-temp (:temperature period) unit)]
-        [:div {:style {:font-size "13px" :color "#9ca3af" :margin-top "8px"}}
+        [:div {:style {:font-size "13px" :color "var(--text-tertiary, #9ca3af)" :margin-top "8px"}}
          (:shortForecast period)]])]))
 
 (defn hourly-view [{:keys [hourly unit]}]
@@ -518,7 +537,7 @@
        [:div {:style {:font-size "64px"}} "✅"]
        [:div {:style {:font-size "18px" :font-weight "500" :margin-top "15px"}}
         "No Active Weather Alerts"]
-       [:div {:style {:font-size "14px" :color "#9ca3af" :margin-top "8px"}}
+       [:div {:style {:font-size "14px" :color "var(--text-tertiary, #9ca3af)" :margin-top "8px"}}
         "All clear! No weather warnings or advisories."]]
 
       [:div

--- a/src/scittle/weather/current_conditions.cljs
+++ b/src/scittle/weather/current_conditions.cljs
@@ -13,8 +13,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -29,8 +30,26 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -228,7 +247,7 @@
 (def temp-display-style
   {:text-align "center"
    :padding "30px 0"
-   :border-bottom "1px solid #e0e0e0"})
+   :border-bottom "1px solid var(--border-color, #e5e7eb)"})
 
 (def large-temp-style
   {:font-size "72px"
@@ -278,7 +297,7 @@
 
 (def metric-label-style
   {:font-size "13px"
-   :color "#9ca3af"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin "0 0 5px 0"
    :font-weight "500"
    :text-transform "uppercase"
@@ -293,15 +312,15 @@
 (def station-info-style
   {:margin-top "20px"
    :padding-top "20px"
-   :border-top "1px solid #e0e0e0"
+   :border-top "1px solid var(--border-color, #e5e7eb)"
    :font-size "13px"
-   :color "#9ca3af"
+   :color "var(--text-tertiary, #9ca3af)"
    :text-align "center"})
 
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#9ca3af"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def error-style
   {:background "#fef2f2"

--- a/src/scittle/weather/forecast_viewer.cljs
+++ b/src/scittle/weather/forecast_viewer.cljs
@@ -13,8 +13,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -29,8 +30,26 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -283,7 +302,7 @@
 
 (def wind-style
   {:font-size "13px"
-   :color "#9ca3af"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin "5px 0"})
 
 (def precip-style
@@ -295,7 +314,7 @@
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#9ca3af"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def error-style
   {:background "#fef2f2"

--- a/src/scittle/weather/hourly_forecast.cljs
+++ b/src/scittle/weather/hourly_forecast.cljs
@@ -13,8 +13,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -29,8 +30,26 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -363,13 +382,13 @@
 
 (def wind-display-style
   {:font-size "12px"
-   :color "#9ca3af"
+   :color "var(--text-tertiary, #9ca3af)"
    :margin "4px 0"})
 
 (def loading-style
   {:text-align "center"
    :padding "40px"
-   :color "#9ca3af"})
+   :color "var(--text-tertiary, #9ca3af)"})
 
 (def error-style
   {:background "#fef2f2"

--- a/src/scittle/weather/simple_lookup.cljs
+++ b/src/scittle/weather/simple_lookup.cljs
@@ -1,11 +1,11 @@
 (ns scittle.weather.simple-lookup
   "Simple weather lookup demo - minimal example showing basic API usage.
-   
+
    This is the simplest possible weather app:
    - Two input fields for coordinates
    - One button to fetch weather
    - Display location and temperature
-   
+
    Demonstrates:
    - Basic API call with keyword arguments
    - Loading state
@@ -27,8 +27,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -43,8 +44,9 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -58,7 +60,24 @@
       --button-text: #f3f4f6;
       --shadow-color: rgba(0, 0, 0, 0.3);
     }
-    
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
     /* Hover states - applied universally */
     button:not(.btn-primary):hover {
       background: var(--button-hover) !important;

--- a/src/scittle/weather/weather_alerts.cljs
+++ b/src/scittle/weather/weather_alerts.cljs
@@ -42,8 +42,9 @@
   "CSS for light and dark mode support using Quarto's data-bs-theme attribute"
   []
   [:style "
-    /* Light mode (default) */
-    [data-bs-theme='light'] {
+    /* Light mode (default) - inherits from parent */
+    [data-bs-theme='light'],
+    [data-bs-theme='light'] * {
       --card-bg: #ffffff;
       --card-secondary-bg: #f9fafb;
       --input-bg: #ffffff;
@@ -58,8 +59,26 @@
       --shadow-color: rgba(0, 0, 0, 0.1);
     }
 
-    /* Dark mode */
-    [data-bs-theme='dark'] {
+    /* Dark mode - inherits from parent */
+    [data-bs-theme='dark'],
+    [data-bs-theme='dark'] * {
+      --card-bg: #1f2937;
+      --card-secondary-bg: #111827;
+      --input-bg: #111827;
+      --text-primary: #f3f4f6;
+      --text-secondary: #d1d5db;
+      --text-tertiary: #9ca3af;
+      --border-color: #374151;
+      --border-color-dark: #4b5563;
+      --button-bg: #374151;
+      --button-hover: #4b5563;
+      --button-text: #f3f4f6;
+      --shadow-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Also check for Quarto's dark class on body */
+    .quarto-dark,
+    .quarto-dark * {
       --card-bg: #1f2937;
       --card-secondary-bg: #111827;
       --input-bg: #111827;
@@ -88,7 +107,7 @@
     "severe" "#ea580c" ; Orange
     "moderate" "#ca8a04" ; Yellow/Gold
     "minor" "#65a30d" ; Green
-    "#6b7280")) ; Gray for unknown
+    "var(--text-secondary, #6b7280)")) ; Gray for unknown
 
 (defn get-urgency-badge-color
   "Map urgency level to badge color."
@@ -97,7 +116,7 @@
     "immediate" "#dc2626"
     "expected" "#f59e0b"
     "future" "#3b82f6"
-    "#6b7280"))
+    "var(--text-secondary, #6b7280)"))
 
 (defn get-certainty-badge-color
   "Map certainty level to badge color."
@@ -106,7 +125,7 @@
     "observed" "#059669"
     "likely" "#3b82f6"
     "possible" "#8b5cf6"
-    "#6b7280"))
+    "var(--text-secondary, #6b7280)"))
 
 (defn get-alert-icon
   "Map alert event to emoji icon."


### PR DESCRIPTION
Update CSS selectors to include descendant selector (*) so child elements properly inherit dark mode CSS variables. Add .quarto-dark fallback for Quarto compatibility.

Previously, cards retained white backgrounds in dark mode because CSS variables only applied to elements with data-bs-theme attribute directly, not their children.

Affects: All 6 weather component files