### PR TITLE
Tweak formatting to help with rendered result

### DIFF
--- a/src/dsp/intro.clj
+++ b/src/dsp/intro.clj
@@ -136,7 +136,8 @@ example-wave
    [:A5 880 2750] ;; 2nd harmonic (octave above)
    [:E6 1320 600] ;; 3rd harmonic
    [:A6 1760 700] ;; 4th harmonic
-   [:C#7 2200 1900]]);; 5th harmonic
+   [:C#7 2200 1900] ;; 5th harmonic
+   ])
 
 ;; Now let's generate all five harmonics as separate columns in a dataset.
 ;; Each harmonic is a sine wave at its own frequency and amplitude.


### PR DESCRIPTION
This PR is an attempt to improve the rendered result of the article [DSP Study Group - Intro: Building the Violin Sound from Sine Waves](https://clojurecivitas.github.io/dsp/intro.html).

Currently, the first code snippet under ["Step 2: Creating Complex Sounds - Violin Synthesis"](https://clojurecivitas.github.io/dsp/intro.html#step-2-creating-complex-sounds---violin-synthesis) appears like this for me:

<img width="830" height="245" alt="cc-dsp-intro" src="https://github.com/user-attachments/assets/9c717638-ab01-4e79-bf41-049af98f035e" />

Note where "5th harmonic" shows up at the bottom.

May be that's something that can be addressed elsewhere (no idea which bit of code would be relevant), but for the time being, it appears that the suggested changes in this PR will yield a slightly nicer result.
