### PR TITLE
Add whitespace before quoting

### DIFF
--- a/src/dsp/wav_files.clj
+++ b/src/dsp/wav_files.clj
@@ -141,6 +141,7 @@ block
 
 ;; As we learned in the [first session](https://clojurecivitas.github.io/dsp/intro.html)
 ;; of the DSP study group:
+
 ;; > Sound waves are continuous vibrations in the air. To work with them on a computer,
 ;; > we need to **sample** them - take measurements at regular intervals. The **sample rate**
 ;; > tells us how many measurements per second. CD-quality audio uses 44,100 samples per second.


### PR DESCRIPTION
This PR is intended to address a "missing empty line before quoting" issue [1] for the ["DSP Study Group - Reading audio data from WAV-files" article](https://clojurecivitas.github.io/dsp/wav_files.html).

Currently, one portion of the article looks like this for me:

<img width="729" height="120" alt="rendering-of-quoting" src="https://github.com/user-attachments/assets/a6b3f11d-4306-4f2d-a094-3c4508521b81" />

For reference, the text is from the 2nd-to-last paragraph of [this section](https://clojurecivitas.github.io/dsp/wav_files.html#simplified-wav-format).

I suspect the intent is for a portion of that text to be quoted.

---

[1] Possibly simialar to what is described in the context of discussion of another aticle [on Zulip](https://clojurians.zulipchat.com/#narrow/channel/150792-announce/topic/ClojureCivitas/near/545830055).  One difference is that no list is involved, but rather quoting.