### PR TITLE
Explanations are value laden: build fix and spelling errors

### DIFF
--- a/src/civitas/why/explanations_are_value_laden.clj
+++ b/src/civitas/why/explanations_are_value_laden.clj
@@ -1,5 +1,5 @@
 ^{:kindly/hide-code true
-  :clay {:title "Explanations are value laden" :quarto {:author :com.github/teodorlu :type :post :date "2025-11-15"}}}
+  :clay {:title "Explanations are value laden" :quarto {:author :com.github/teodorlu :type :post :date "2025-11-16"}}}
 (ns civitas.why.explanations-are-value-laden
   (:require [scicloj.kindly.v4.kind :as kind]))
 


### PR DESCRIPTION
The build somehow didn't like :as-alias, and failed with this message:

https://github.com/ClojureCivitas/clojurecivitas.github.io/actions/runs/19390638787/job/55483583237#step:8:227

I tried to reproduce quickly in a blank REPL, but it looks to me like this should be okay.

```
teodorlu@photondrive2 ~ % clj
Clojure 1.12.0
user=> (require '[teodorlu :as-alias t])
nil
user=> ::t/blabla
:teodorlu/blabla
```