### PR TITLE
ci: enable workflow_dispatch on render-and-publish

### DIFF
--- a/.github/workflows/render-and-publish.yml
+++ b/.github/workflows/render-and-publish.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 name: Render and Publish
 


### PR DESCRIPTION
Adds the workflow_dispatch trigger so the workflow can be run manually from the Actions tab against an arbitrary branch. Lets PR authors get green-build feedback before merge.

No behavior change for the existing `push: main` flow.

  After merge, the "Render and Publish" workflow gets a "Run workflow" button in the Actions tab; selecting a non-main branch dispatches that branch's workflow
  file.

