### PR TITLE
Add Bayes-to-Lexibench Civitas article series

### DIFF
--- a/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
+++ b/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
@@ -1,0 +1,306 @@
+^{:kindly/hide-code true
+  :kindly/options {:html/deps [:scittle :reagent]}
+  :clay {:title "Bayes' Theorem, Revisited: Three Interactive Simulations"
+         :quarto {:author :jamiep
+                  :description "Rebuilding three earlier Bayesian simulations with Kindly, Scittle, Reagent, and accessible SVG."
+                  :type :post
+                  :date "2026-07-13"
+                  :category :concepts
+                  :tags [:bayesian-statistics :clojure :clojurescript :scittle :simulation]
+                  :keywords [:bayes-theorem :grid-approximation :posterior-sampling :normal-distribution :data-visualisation]}}}
+
+(ns language-learning.vocabulary-estimation.bayes-theorem-simulations
+  (:require [scicloj.kindly.v4.kind :as kind]))
+
+^:kindly/hide-code
+(kind/hiccup
+ [:style
+  "#title-block-header{padding-top:.75rem}#title-block-header h1{line-height:1.15;overflow-wrap:anywhere}mjx-container[display=true]{max-width:100%;overflow-x:auto;overflow-y:hidden}.bp-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.25rem}.bp-callout strong{display:block;margin-bottom:.3rem}.bp-simulator{margin:1.5rem 0}.bp-shell{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.bp-shell h3{margin-top:0}.bp-shell h4{font-size:1rem}.bp-details{border:1px solid #dee2e6;border-radius:.45rem;margin:.85rem 0;background:var(--bs-body-bg,#fff)}.bp-details summary{cursor:pointer;font-weight:700;padding:.75rem 1rem}.bp-details>div{padding:0 1rem 1rem}.bp-controls{display:flex;align-items:end;gap:.65rem;flex-wrap:wrap;margin:1rem 0}.bp-controls label,.bp-field label{font-weight:700;font-size:.88rem}.bp-controls input[type=range]{width:min(15rem,100%);accent-color:#2780e3}.bp-button{border:1px solid #6c757d;border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.bp-button.bp-primary,.bp-button[aria-pressed=true]{border-color:#2780e3;background:#2780e3;color:#fff}.bp-button:disabled{opacity:.45;cursor:not-allowed}.bp-button:focus-visible,.bp-select:focus-visible,.bp-controls input:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 45%,transparent);outline-offset:2px}.bp-select{border:1px solid #6c757d;border-radius:.35rem;padding:.5rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.bp-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,20rem),1fr));gap:1rem;margin:1rem 0}.bp-chart{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:.7rem;margin:0;background:var(--bs-body-bg,#fff)}.bp-chart h4{margin:.1rem 0 .2rem;font-size:.95rem;line-height:1.25}.bp-chart svg{display:block;width:100%;height:auto}.bp-caption,.bp-note{font-size:.86rem;color:var(--bs-secondary-color,#5c636a);margin:.4rem 0 0}.bp-stat{font-variant-numeric:tabular-nums;margin:.4rem 0}.bp-sample-sequence{font-family:var(--bs-font-monospace,monospace);font-size:.82rem;overflow-wrap:anywhere;max-height:6rem;overflow:auto;padding:.55rem;border-radius:.35rem;background:var(--bs-tertiary-bg,#f4f4f4)}.bp-axis{stroke:currentColor;stroke-opacity:.5}.bp-guide{stroke:currentColor;stroke-opacity:.11}.bp-line{fill:none;stroke:#2780e3;stroke-width:3;vector-effect:non-scaling-stroke}.bp-line-secondary{fill:none;stroke:#e69f00;stroke-width:2;stroke-dasharray:6 4;vector-effect:non-scaling-stroke}.bp-bar-water{fill:#2780e3}.bp-bar-land{fill:#c99052}.bp-points{fill:none;stroke:#2780e3;stroke-width:2;stroke-linecap:round;vector-effect:non-scaling-stroke}.bp-progress{width:100%;height:.55rem;accent-color:#2780e3}.bp-formula{font-family:var(--bs-font-monospace,monospace);overflow-wrap:anywhere}.bp-heat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,17rem),1fr));gap:1rem}.bp-empty{display:grid;place-items:center;min-height:11rem;border:1px dashed #adb5bd;border-radius:.35rem;color:var(--bs-secondary-color,#5c636a);text-align:center;padding:1rem}.bp-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}@media(max-width:575px){.bp-shell{padding:.75rem}.bp-controls{align-items:stretch}.bp-button{flex:1}.bp-chart{padding:.5rem}}"])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:style
+  ".series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--bs-secondary-color,#5c636a)}.bp-change-details>summary{font-size:1.3rem;line-height:1.2}.bp-change-details ul{margin-bottom:0}"])
+
+;; I thought I'd reproduce my previous learning about [Bayes' theorem
+;; simulations](https://jointprob.github.io/jointprob-shadow-cljs/#normal-distribution)
+;; ([source code](https://github.com/jointprob/jointprob-shadow-cljs/tree/master/src/cljs))
+;; as a Civitas article. I previously produced these simulations when I was
+;; working with [Daniel's JointProb
+;; group](https://scicloj.github.io/docs/community/groups/jointprob/) and used
+;; visualisation tools that were easily available at the time. I'm pretty
+;; confident that the current visualisation tools are going to do a lot better
+;; job with this simulation, judging by how wonderful a job they did with [my
+;; first Civitas article](beta_binomial_first_pass.html).
+
+^:kindly/hide-code
+(kind/hiccup
+ [:nav.series-toc {:aria-labelledby "series-contents-heading"}
+  [:h2#series-contents-heading "Series contents"]
+  [:p
+   [:strong "Revisiting basic Bayes' theorem and applying it to a real word problem: estimating vocabulary size from "]
+   [:a {:href "https://lexibench.com/"} "Lexibench.com"]
+   [:strong " quiz responses."]]
+  [:ol
+   [:li [:a {:href "bayes_theorem_simulations.html"}
+         "Bayes' Theorem, Revisited: Three Interactive Simulations"]
+    [:span.series-status "published"]]
+   [:li [:a {:href "beta_binomial_first_pass.html"}
+         "Estimating Vocabulary Size with a Simple Bayesian Model"]
+    [:span.series-status "published"]]
+   [:li "Does Pair Frequency Predict Learner Responses?"
+    [:span.series-status "planned"]]
+   [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
+    [:span.series-status "planned"]]
+   [:li "From Correlated Form Pairs to Latent Lemma Knowledge"
+    [:span.series-status "planned"]]
+   [:li "Modelling Correct, Wrong, and Don't-Know Separately"
+    [:span.series-status "planned"]]
+   [:li "Calibrating Items Before IRT and Adaptive Selection"
+    [:span.series-status "planned"]]
+   [:li "When Contexts and Senses Become Identifiable"
+    [:span.series-status "planned"]]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:details.bp-details.bp-change-details
+  [:summary "What I changed in this recreation"]
+  [:div
+   [:p "I kept the old application's complete three-part teaching sequence and its numerical grids, but rebuilt how it is delivered:"]
+   [:ul
+    [:li "The three routed Shadow-CLJS pages are now one executable Civitas article, so the globe update, posterior-sampling decision, and Gaussian update can be read as one argument."]
+    [:li "The compiled Shadow-CLJS application is replaced by the same Kindly–Scittle–Reagent arrangement used in my first article. The mathematical core lives in this " [:code ".clj"] " article; browser state and controls live in one adjacent " [:code ".cljs"] " file."]
+    [:li "Vega, Hanami, Semantic UI React, and MathJax React are removed. Kindly and Quarto render the prose and equations; semantic HTML supplies the controls; Reagent renders the visualisations directly as responsive SVG."]
+    [:li "The original 201-point probability grid, four selectable priors, 200-item globe simulation, 2,000 animated posterior draws, 10,000-draw comparison, 41 × 41 Gaussian parameter grid, and complete adult-height dataset are preserved."]
+    [:li "Previously ambient calls to " [:code "rand"] " are replaced by explicit seeds. Reset now replays the same globe data and posterior draws, making screenshots, explanations, and later regression checks reproducible."]
+    [:li "The old long quotations from " [:em "Statistical Rethinking"] " are paraphrased while retaining their examples, section references, and attribution."]
+    [:li "Every chart now has an SVG title and description; controls have associated labels and explicit keyboard behavior; status text is announced selectively; and the layout collapses without horizontal overflow on small screens."]
+    [:li "The Gaussian heat maps use within-panel logarithmic opacity. This keeps low but non-zero plausibilities visible as the posterior concentrates. Their colour is therefore for comparing location and shape within a panel, not absolute density across panels."]
+    [:li "I added direct " [:strong "Previous"] " and " [:strong "Next"] " controls to the height simulation and bounded its final update, avoiding the old end-of-data indexing edge case."]]
+   [:p "The original project was a three-page Shadow-CLJS application using Vega, Hanami, Semantic UI React, and MathJax React. This version keeps the three lessons together in one executable Civitas article. Kindly renders the article, while Scittle and Reagent run the controls directly in the browser. The charts are responsive SVG with text alternatives, so there is no JavaScript build step and no charting wrapper between the data and the marks."]
+   [:p "All simulated randomness below is seeded. Resetting a simulation replays the same sequence, which makes the explanations and any later checks repeatable."]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-callout
+  [:strong "What is being recreated"]
+  "The globe-toss grid approximation, sampling from its posterior to make a decision under absolute loss, and sequential Gaussian updating for adult heights. The long quotations in the old application are paraphrased here and still attributed to their source."])
+
+;; ## 1. Updating a probability with globe tosses
+;;
+;; The first example follows the globe thought experiment in section 2.2 of
+;; Richard McElreath's *Statistical Rethinking*. Toss a small globe, catch it,
+;; and note whether the point beneath your index finger is water or land. The
+;; unknown parameter $p$ is the proportion of the globe covered by water.
+;;
+;; I approximate the continuous range of $p$ using 201 candidates:
+;;
+;; $$p \in \{0, 0.005, 0.010, \ldots, 0.995, 1\}.$$
+
+(def probability-grid
+  (mapv #(/ % 200.0) (range 201)))
+
+(defn binomial-coefficient
+  "Number of orderings containing k successes among n observations."
+  [n k]
+  {:pre [(<= 0 k n)]}
+  (let [k (min k (- n k))]
+    (reduce (fn [acc i]
+              (* acc (/ (- (inc n) i) i)))
+            1.0
+            (range 1 (inc k)))))
+
+(defn normalize-mean-one
+  "Scale non-negative grid weights so their arithmetic mean is one."
+  [weights]
+  (let [mean-weight (/ (reduce + weights) (count weights))]
+    (if (pos? mean-weight)
+      (mapv #(/ % mean-weight) weights)
+      (vec weights))))
+
+(defn binomial-likelihood
+  "Likelihood of water and land counts for one candidate p."
+  [p water land]
+  (* (binomial-coefficient (+ water land) water)
+     (Math/pow p water)
+     (Math/pow (- 1.0 p) land)))
+
+(defn grid-posterior
+  "Posterior grid weights for a prior and water/land observations."
+  [prior water land]
+  (->> probability-grid
+       (mapv #(binomial-likelihood % water land))
+       (mapv * prior)
+       normalize-mean-one))
+
+(def uniform-prior (vec (repeat 201 1.0)))
+
+(def example-posterior
+  (grid-posterior uniform-prior 6 3))
+
+{:grid-points (count probability-grid)
+ :example :six-water-three-land
+ :posterior-mode (first (apply max-key second
+                               (map vector probability-grid example-posterior)))}
+
+;; For $W$ water observations and $L$ land observations, the probability of one
+;; particular ordered sequence is
+;;
+;; $$p^W(1-p)^L.$$
+;;
+;; There are
+;;
+;; $$\binom{W+L}{W}=\frac{(W+L)!}{W!L!}$$
+;;
+;; orderings with the same counts, giving the binomial likelihood
+;;
+;; $$\Pr(W,L\mid p)=\binom{W+L}{W}p^W(1-p)^L.$$
+;;
+;; Bayes' theorem combines that likelihood with the prior:
+;;
+;; $$\Pr(p\mid W,L)=\frac{\Pr(W,L\mid p)\Pr(p)}{\Pr(W,L)},$$
+;;
+;; where the denominator is the average probability of the data across the
+;; prior. On a grid, normalising the products performs the same job.
+;;
+;; The simulator restores all four priors from the old application: uniform,
+;; step up, step down, and a symmetric ramp. Add water or land deliberately, or
+;; let a seeded process whose true water probability is 0.6 generate up to 200
+;; observations. The panels separate the previous posterior, the latest
+;; observation's likelihood, the full likelihood, and the new posterior.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-simulator
+  [:div#globe-update-simulator
+   [:p "Loading the globe-toss Bayesian update simulator…"]]
+  [:noscript "This simulator needs JavaScript. The equations and executable Clojure above remain available without it."]])
+
+;; The ordered-sequence likelihood and the likelihood of any ordering have the
+;; same shape as functions of $p$: the binomial coefficient is constant for
+;; fixed $W$ and $L$. Their raw vertical scales differ, but normalising either
+;; curve produces the same visual shape. Keeping both panels makes that fact
+;; visible rather than leaving it buried in the algebra.
+;;
+;; ## 2. Sampling from the posterior and choosing a decision
+;;
+;; Section 3.2 of *Statistical Rethinking* turns the globe problem into a bet.
+;; Choose a value $d$ for the proportion of water. A perfect answer earns $100$,
+;; but the payoff falls in proportion to the absolute error $|d-p|$. As in the
+;; previous application, I make that concrete as a loss of $1 for every 0.01 of
+;; error.
+;;
+;; The browser first generates a reproducible dataset of 100 globe observations
+;; with true $p=0.6$, then calculates its grid posterior. For every candidate
+;; decision $d$, the expected absolute loss is
+;;
+;; $$E[|d-p|\mid W,L] = \sum_p |d-p|\Pr(p\mid W,L).$$
+
+(defn expected-absolute-loss
+  "Expected absolute error at decision d for grid weights."
+  [posterior d]
+  (let [weight-total (reduce + posterior)]
+    (/ (reduce + (map (fn [p weight]
+                        (* (Math/abs (- d p)) weight))
+                      probability-grid
+                      posterior))
+       weight-total)))
+
+(def example-losses
+  (mapv #(expected-absolute-loss example-posterior %)
+        probability-grid))
+
+(def example-minimum-loss
+  (apply min-key second (map vector probability-grid example-losses)))
+
+{:example :six-water-three-land
+ :minimum-loss-decision (first example-minimum-loss)
+ :expected-absolute-loss (second example-minimum-loss)}
+
+;; The direct calculation iterates over decisions from 0 to 1 in steps of
+;; 0.005. For each decision it multiplies the loss at every possible $p$ by that
+;; $p$'s posterior weight and averages over the curve. The lowest point of the
+;; resulting loss curve is the decision that minimises expected loss.
+;;
+;; We can reach the same answer by drawing possible values of $p$ from the
+;; posterior. Under absolute loss, the posterior median is the optimal
+;; decision. The interactive view animates up to 2,000 draws, then compares
+;; their trace, 200-bin counts, and standardised density with a fixed 10,000-draw
+;; simulation. Every visible summary uses the draws shown by that simulation.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-simulator
+  [:div#posterior-sampling-simulator
+   [:p "Loading the posterior sampling and decision simulator…"]]
+  [:noscript "This simulator needs JavaScript. The expected-loss calculation above remains available without it."]])
+
+;; ## 3. Updating a Gaussian model for adult heights
+;;
+;; The final simulation follows section 4.3 of *Statistical Rethinking*. A
+;; Gaussian distribution has two parameters: its mean $\mu$ and standard
+;; deviation $\sigma$. There are infinitely many possible pairs, so the
+;; original exercise considers a finite grid and ranks each candidate Gaussian
+;; by how compatible it is with the observed adult heights.
+;;
+;; For an observed height $h$, a candidate $(\mu,\sigma)$ has density
+;;
+;; $$f(h\mid\mu,\sigma)=
+;; \frac{1}{\sigma\sqrt{2\pi}}
+;; \exp\left(-\frac{(h-\mu)^2}{2\sigma^2}\right).$$
+
+(defn normal-density
+  "Gaussian probability density at x."
+  [x mean sd]
+  (/ (Math/exp (/ (* -0.5 (Math/pow (- x mean) 2.0))
+                  (Math/pow sd 2.0)))
+     (* (Math/sqrt (* 2.0 Math/PI)) sd)))
+
+(normal-density 151.765 155.0 8.0)
+
+;; The grid matches the old simulation: 41 values of $\mu$ from 150 to 160 and
+;; 41 values of $\sigma$ from 7 to 9, or 1,681 candidate Gaussians. The prior is
+;; uniform over $\sigma$ and gives $\mu$ a Normal(178, 20) density. For each
+;; height, the display shows three heat maps:
+;;
+;; 1. the posterior before considering the next height;
+;; 2. the relative likelihood supplied by that height;
+;; 3. the posterior after multiplying and normalising.
+;;
+;; Move one height at a time or play through the complete dataset. A logarithmic
+;; colour scale keeps low but non-zero plausibilities visible after the
+;; posterior becomes concentrated.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-simulator
+  [:div#gaussian-height-simulator
+   [:p "Loading the sequential Gaussian updating simulator…"]]
+  [:noscript "This simulator needs JavaScript. The Gaussian density and explanation above remain available without it."]
+  [:script {:type "application/x-scittle"
+            :src "bayes_theorem_simulations_interactive.cljs"}]])
+
+;; ## What this recreation is for
+;;
+;; This is deliberately a record of my earlier learning. It does not
+;; silently turn these examples into the vocabulary estimator described in my
+;; first Civitas article; it exposes the probability tools that helped me get
+;; there.
+;;
+;; ## Sources
+;;
+;; - Jamie Pratt and the JointProb group, [original interactive simulations](https://jointprob.github.io/jointprob-shadow-cljs/#normal-distribution) and [ClojureScript source](https://github.com/jointprob/jointprob-shadow-cljs/tree/master/src/cljs).
+;; - Richard McElreath, *Statistical Rethinking*, examples from sections 2.2, 3.2, and 4.3. The prompts above are paraphrases.
+;; - [My first Civitas article: *Estimating Vocabulary Size with a Simple Bayesian Model*](beta_binomial_first_pass.html).
+
+^:kindly/hide-code
+(do
+  (assert (= 201 (count probability-grid)))
+  (assert (< (Math/abs (- 84.0 (binomial-coefficient 9 6))) 1.0e-12))
+  (assert (< (Math/abs (- 1.0
+                          (/ (reduce + example-posterior)
+                             (count example-posterior))))
+             1.0e-12))
+  (assert (= 0.645 (first example-minimum-loss)))
+  (assert (pos? (normal-density 151.765 155.0 8.0)))
+  :verified)

--- a/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs
@@ -1,0 +1,811 @@
+(ns language-learning.vocabulary-estimation.bayes-theorem-simulations-interactive
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [reagent.dom :as rdom]))
+
+;; Shared deterministic random-number generator and probability helpers.
+
+(defn make-rng [seed]
+  #js {:state (mod seed 2147483647)})
+
+(defn uniform! [rng]
+  (let [next-state (mod (* 48271 (.-state rng)) 2147483647)]
+    (set! (.-state rng) next-state)
+    (/ (dec next-state) 2147483646.0)))
+
+(def probability-grid
+  (mapv #(/ % 200.0) (range 201)))
+
+(defn binomial-coefficient [n k]
+  (let [k (min k (- n k))]
+    (reduce (fn [acc i]
+              (* acc (/ (- (inc n) i) i)))
+            1.0
+            (range 1 (inc k)))))
+
+(defn normalize-mean-one [values]
+  (let [mean-value (/ (reduce + values) (count values))]
+    (if (pos? mean-value)
+      (mapv #(/ % mean-value) values)
+      (vec values))))
+
+(defn normalize-mass [values]
+  (let [total (reduce + values)]
+    (if (pos? total)
+      (mapv #(/ % total) values)
+      (vec values))))
+
+(defn observation-counts [samples]
+  (let [water (count (filter #{:water} samples))
+        land (- (count samples) water)]
+    {:n (count samples) :water water :land land}))
+
+(defn sequence-likelihood [p water land]
+  (* (js/Math.pow p water)
+     (js/Math.pow (- 1 p) land)))
+
+(defn binomial-likelihood [p water land]
+  (* (binomial-coefficient (+ water land) water)
+     (sequence-likelihood p water land)))
+
+(defn standard-posterior [prior samples]
+  (let [{:keys [water land]} (observation-counts samples)]
+    (->> probability-grid
+         (mapv #(binomial-likelihood % water land))
+         (mapv * prior)
+         normalize-mean-one)))
+
+(def uniform-prior (vec (repeat 201 1.0)))
+(def step-up-prior (mapv #(if (<= % 0.5) 0.0 2.0) probability-grid))
+(def step-down-prior (mapv #(if (<= % 0.5) 2.0 0.0) probability-grid))
+(def ramp-prior
+  (normalize-mean-one
+   (mapv #(js/Math.pow 1.08 (* 200 (if (<= % 0.5) % (- 1 %))))
+         probability-grid)))
+
+(def prior-options
+  [{:label "Uniform" :values uniform-prior}
+   {:label "Step up" :values step-up-prior}
+   {:label "Step down" :values step-down-prior}
+   {:label "Ramp up and down" :values ramp-prior}])
+
+(def priors-by-label
+  (into {} (map (juxt :label :values) prior-options)))
+
+(def number-formatter (js/Intl.NumberFormat. "en-US"))
+
+(defn format-number [number]
+  (.format number-formatter number))
+
+(defn format-decimal [number digits]
+  (.toFixed number digits))
+
+(defn counted-label [number singular]
+  (str number " " singular (when (not= number 1) "s")))
+
+;; Accessible SVG primitives. The old application delegated these marks to
+;; Vega; this recreation keeps the transformation visible in ClojureScript.
+
+(defn x-position [index point-count]
+  (+ 52 (* index (/ 548 (max 1 (dec point-count))))))
+
+(defn y-position [value maximum]
+  (- 218 (* 174 (/ value (max maximum 1.0e-12)))))
+
+(defn values-path [values]
+  (let [maximum (apply max 1.0e-12 values)
+        point-count (count values)]
+    (str/join
+     " "
+     (map-indexed
+      (fn [index value]
+        (str (if (zero? index) "M" "L")
+             (x-position index point-count) " "
+             (y-position value maximum)))
+      values))))
+
+(defn line-chart
+  [{:keys [id title description values secondary-values x-label y-label]}]
+  (let [all-values (into (vec values) (or secondary-values []))
+        maximum (apply max 1.0e-12 all-values)]
+    [:figure.bp-chart
+     [:h4 title]
+     [:svg {:view-box "0 0 640 285"
+            :role "img"
+            :aria-labelledby (str id "-title " id "-desc")}
+      [:title {:id (str id "-title")} title]
+      [:desc {:id (str id "-desc")} description]
+      (for [[p label] [[0 "0"] [0.25 ".25"] [0.5 ".50"] [0.75 ".75"] [1 "1"]]
+            :let [x (+ 52 (* 548 p))]]
+        ^{:key p}
+        [:g
+         [:line.bp-guide {:x1 x :x2 x :y1 44 :y2 218}]
+         [:text {:x x :y 240 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+          label]])
+      [:line.bp-axis {:x1 52 :x2 600 :y1 218 :y2 218}]
+      [:line.bp-axis {:x1 52 :x2 52 :y1 44 :y2 218}]
+      [:text {:x 326 :y 273 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+       x-label]
+      [:text {:x 54 :y 27 :font-size 12 :fill "currentColor"} y-label]
+      [:path.bp-line {:d (values-path values)}]
+      (when secondary-values
+        [:path.bp-line-secondary
+         {:d (let [point-count (count secondary-values)]
+               (str/join
+                " "
+                (map-indexed
+                 (fn [index value]
+                   (str (if (zero? index) "M" "L")
+                        (x-position index point-count) " "
+                        (y-position value maximum)))
+                 secondary-values)))}])]]))
+
+(defn proportion-chart [{:keys [water land]} id]
+  (let [n (+ water land)
+        water-rate (if (pos? n) (/ water n) 0)
+        land-rate (if (pos? n) (/ land n) 0)]
+    [:figure.bp-chart
+     [:h4 (str "Observed sample · n = " n)]
+     [:svg {:view-box "0 0 640 285"
+            :role "img"
+            :aria-labelledby (str id "-title " id "-desc")}
+      [:title {:id (str id "-title")} "Observed water and land proportions"]
+      [:desc {:id (str id "-desc")}
+       (str water " water and " land " land observations out of " n ".")]
+      (for [[rate label] [[0 "0%"] [0.25 "25%"] [0.5 "50%"] [0.75 "75%"] [1 "100%"]]
+            :let [y (- 218 (* 174 rate))]]
+        ^{:key rate}
+        [:g
+         [:line.bp-guide {:x1 52 :x2 600 :y1 y :y2 y}]
+         [:text {:x 46 :y (+ y 4) :text-anchor "end" :font-size 11 :fill "currentColor"}
+          label]])
+      [:line.bp-axis {:x1 52 :x2 600 :y1 218 :y2 218}]
+      [:rect.bp-bar-water {:x 150 :y (- 218 (* 174 water-rate))
+                           :width 110 :height (* 174 water-rate)}]
+      [:rect.bp-bar-land {:x 375 :y (- 218 (* 174 land-rate))
+                          :width 110 :height (* 174 land-rate)}]
+      [:text {:x 205 :y 241 :text-anchor "middle" :font-size 13 :fill "currentColor"}
+       (str "Water " (format-decimal (* 100 water-rate) 1) "%")]
+      [:text {:x 430 :y 241 :text-anchor "middle" :font-size 13 :fill "currentColor"}
+       (str "Land " (format-decimal (* 100 land-rate) 1) "%")]
+      [:text {:x 326 :y 273 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+       "Outcome"]]]))
+
+(defn control-button
+  ([label on-click] (control-button label on-click {}))
+  ([label on-click attributes]
+   [:button (merge {:type "button"
+                    :class "bp-button"
+                    :on-click on-click
+                    :on-key-down (fn [event]
+                                   (when (contains? #{"Enter" " "} (.-key event))
+                                     (.preventDefault event)
+                                     (on-click)))}
+                   attributes)
+    label]))
+
+;; Simulation 1: sequential globe observations.
+
+(def max-update-samples 200)
+(def update-seed 20260713)
+(def initial-update-state
+  {:prior "Uniform" :samples [] :speed 1.0 :running? false :timer nil})
+(defonce update-state (r/atom initial-update-state))
+(defonce update-rng (atom (make-rng update-seed)))
+
+(defn cancel-update-timer! []
+  (when-let [timer (:timer @update-state)]
+    (js/clearTimeout timer))
+  (swap! update-state assoc :timer nil :running? false))
+
+(defn generated-observation! []
+  (if (< (uniform! @update-rng) 0.6) :water :land))
+
+(defn add-generated-observations! [amount]
+  (let [remaining (- max-update-samples (count (:samples @update-state)))
+        amount (min amount remaining)
+        additions (vec (repeatedly amount generated-observation!))]
+    (swap! update-state update :samples into additions)))
+
+(defn add-observation! [outcome]
+  (when (< (count (:samples @update-state)) max-update-samples)
+    (swap! update-state update :samples conj outcome)))
+
+(declare update-tick!)
+
+(defn schedule-update-tick! []
+  (let [delay (/ 1000 (:speed @update-state))]
+    (swap! update-state assoc :timer (js/setTimeout update-tick! delay))))
+
+(defn update-tick! []
+  (when (:running? @update-state)
+    (add-generated-observations! 1)
+    (if (< (count (:samples @update-state)) max-update-samples)
+      (schedule-update-tick!)
+      (swap! update-state assoc :running? false :timer nil))))
+
+(defn start-update! []
+  (when (= max-update-samples (count (:samples @update-state)))
+    (reset! update-rng (make-rng update-seed))
+    (swap! update-state assoc :samples []))
+  (cancel-update-timer!)
+  (swap! update-state assoc :running? true)
+  (update-tick!))
+
+(defn reset-update! []
+  (cancel-update-timer!)
+  (reset! update-rng (make-rng update-seed))
+  (let [prior (:prior @update-state)
+        speed (:speed @update-state)]
+    (reset! update-state (assoc initial-update-state :prior prior :speed speed))))
+
+(defn remove-observations! [amount]
+  (swap! update-state update :samples
+         #(vec (drop-last (min amount (count %)) %))))
+
+(defn globe-update-simulator []
+  (let [{:keys [prior samples speed running?]} @update-state
+        selected-prior (get priors-by-label prior)
+        previous-samples (vec (butlast samples))
+        counts (observation-counts samples)
+        previous-counts (observation-counts previous-samples)
+        current-posterior (standard-posterior selected-prior samples)
+        previous-posterior (standard-posterior selected-prior previous-samples)
+        latest (peek samples)
+        latest-likelihood (mapv (fn [p]
+                                  (case latest
+                                    :water p
+                                    :land (- 1 p)
+                                    1.0))
+                                probability-grid)
+        ordered-likelihood (normalize-mean-one
+                            (mapv #(sequence-likelihood % (:water counts) (:land counts))
+                                  probability-grid))
+        any-order-likelihood (normalize-mean-one
+                              (mapv #(binomial-likelihood % (:water counts) (:land counts))
+                                    probability-grid))
+        combination-count (binomial-coefficient (:n counts) (:water counts))]
+    [:section.bp-shell {:aria-labelledby "globe-simulator-heading"}
+     [:h3#globe-simulator-heading "Calculate a posterior distribution"]
+     [:details.bp-details
+      [:summary "Question"]
+      [:div
+       [:p "Toss and catch a globe repeatedly. Record whether the point beneath your index finger is water or land. What do those observations imply about p, the proportion of the globe covered by water?"]
+       [:p.bp-note "Adapted from Richard McElreath, Statistical Rethinking, section 2.2."]]]
+     [:div.bp-field
+      [:label {:for "prior-choice"} "Prior before any data"]
+      [:select#prior-choice.bp-select
+       {:value prior
+        :on-change #(swap! update-state assoc :prior (.. % -target -value))}
+       (for [{:keys [label]} prior-options]
+         ^{:key label} [:option {:value label} label])]]
+     [:div.bp-controls
+      [control-button (if running? "Pause" "Play")
+       #(if running? (cancel-update-timer!) (start-update!))
+       {:class "bp-button bp-primary" :aria-pressed running?}]
+      [:label {:for "update-speed"} "Speed"]
+      [:input#update-speed
+       {:type "range" :min 0.5 :max 10 :step 0.5 :value speed
+        :on-change #(swap! update-state assoc :speed
+                           (js/parseFloat (.. % -target -value)))}]
+      [:span (str speed " samples/second")]
+      [control-button "Random sample" #(add-generated-observations! 1)
+       {:disabled (>= (:n counts) max-update-samples)}]
+      [control-button "+10" #(add-generated-observations! 10)
+       {:disabled (> (+ (:n counts) 10) max-update-samples)}]
+      [control-button "Water" #(add-observation! :water)
+       {:disabled (>= (:n counts) max-update-samples)}]
+      [control-button "Land" #(add-observation! :land)
+       {:disabled (>= (:n counts) max-update-samples)}]
+      [control-button "Remove one" #(remove-observations! 1)
+       {:disabled (zero? (:n counts))}]
+      [control-button "Remove 10" #(remove-observations! 10)
+       {:disabled (< (:n counts) 10)}]
+      [control-button "Clear" reset-update!
+       {:disabled (zero? (:n counts))}]]
+     [:p.bp-stat {:aria-live "polite"}
+      [:strong (str (:water counts) " water, " (:land counts) " land, " (:n counts) " total. ")]
+      (str "Latest observation: " (if latest (name latest) "none") ".")]
+     [:div.bp-sample-sequence
+      (if (seq samples)
+        (str/join " " (map #(if (= % :water) "W" "L") samples))
+        "No observations yet.")]
+     [:details.bp-details
+      [:summary "Formulae for the current observations"]
+      [:div
+       [:p.bp-formula
+        (str "One ordered sequence: p^" (:water counts)
+             "(1-p)^" (:land counts))]
+       [:p.bp-formula
+        (str "Possible orderings: (" (:water counts) "+" (:land counts)
+             ")!/(" (:water counts) "!" (:land counts) "!) = "
+             (format-number combination-count))]
+       [:p.bp-formula
+        (str "Any ordering: " (format-number combination-count)
+             " p^" (:water counts) "(1-p)^" (:land counts))]
+       [:p.bp-formula "Posterior ∝ likelihood × prior; the grid weights are then normalised."]]]
+     [:div.bp-grid
+      [proportion-chart counts "globe-sample-bars"]
+      [line-chart {:id "chosen-prior" :title (str prior " prior")
+                   :description (str "The selected " prior " prior across water proportion p.")
+                   :values selected-prior :x-label "Water proportion p" :y-label "Prior weight"}]
+      [line-chart {:id "previous-posterior" :title (str "Previous posterior · n = " (:n previous-counts))
+                   :description "Posterior before the latest observation."
+                   :values previous-posterior :x-label "Water proportion p" :y-label "Relative density"}]
+      [line-chart {:id "latest-likelihood" :title (str "Latest-observation likelihood · " (or (some-> latest name) "none"))
+                   :description "Likelihood supplied by the latest water or land observation."
+                   :values latest-likelihood :x-label "Water proportion p" :y-label "Likelihood"}]
+      [line-chart {:id "ordered-likelihood" :title "This ordered sequence"
+                   :description "Relative likelihood of this exact ordered water and land sequence."
+                   :values ordered-likelihood :x-label "Water proportion p" :y-label "Relative likelihood"}]
+      [line-chart {:id "any-order-likelihood" :title "Any ordering with these counts"
+                   :description "Relative binomial likelihood of any ordering with these water and land counts."
+                   :values any-order-likelihood :x-label "Water proportion p" :y-label "Relative likelihood"}]
+      [line-chart {:id "current-posterior" :title "Current posterior"
+                   :description "Current posterior distribution after combining the full likelihood and selected prior."
+                   :values current-posterior :x-label "Water proportion p" :y-label "Relative density"}]]
+     [:p.bp-note "Random observations use true p = 0.6 and seed 20260713. Reset replays the same sequence. The two full-likelihood panels share a normalised shape because their binomial coefficient differs only by a constant."]]))
+
+;; Simulation 2: posterior sampling and absolute-loss decisions.
+
+(def posterior-data-seed 320260713)
+(def posterior-draw-seed 420260713)
+(def fixed-draw-seed 520260713)
+
+(def fixed-globe-samples
+  (let [rng (make-rng posterior-data-seed)]
+    (vec (repeatedly 100 #(if (< (uniform! rng) 0.6) :water :land)))))
+
+(def fixed-globe-counts (observation-counts fixed-globe-samples))
+(def fixed-posterior (standard-posterior uniform-prior fixed-globe-samples))
+(def fixed-posterior-mass (normalize-mass fixed-posterior))
+
+(defn weighted-grid-sample! [rng]
+  (let [target (uniform! rng)]
+    (loop [index 0
+           cumulative (first fixed-posterior-mass)]
+      (if (or (>= cumulative target)
+              (= index (dec (count fixed-posterior-mass))))
+        (nth probability-grid index)
+        (recur (inc index)
+               (+ cumulative (nth fixed-posterior-mass (inc index))))))))
+
+(def fixed-ten-thousand-samples
+  (let [rng (make-rng fixed-draw-seed)]
+    (vec (repeatedly 10000 #(weighted-grid-sample! rng)))))
+
+(defn expected-loss [decision]
+  (reduce + (map (fn [p mass]
+                   (* (js/Math.abs (- decision p)) mass))
+                 probability-grid
+                 fixed-posterior-mass)))
+
+(def loss-values (mapv expected-loss probability-grid))
+(def minimum-loss-pair
+  (reduce (fn [[best-p best-loss] [p loss]]
+            (if (< loss best-loss) [p loss] [best-p best-loss]))
+          [0 js/Infinity]
+          (map vector probability-grid loss-values)))
+
+(defn median [numbers]
+  (let [ordered (vec (sort numbers))]
+    (nth ordered (js/Math.floor (/ (count ordered) 2)))))
+
+(def fixed-posterior-median (median fixed-ten-thousand-samples))
+(def maximum-posterior-samples 2000)
+(def initial-posterior-sampling-state
+  {:samples [] :speed 50 :running? false :timer nil})
+(defonce posterior-sampling-state (r/atom initial-posterior-sampling-state))
+(defonce posterior-sampling-rng (atom (make-rng posterior-draw-seed)))
+
+(defn cancel-posterior-timer! []
+  (when-let [timer (:timer @posterior-sampling-state)]
+    (js/clearTimeout timer))
+  (swap! posterior-sampling-state assoc :timer nil :running? false))
+
+(defn add-posterior-samples! []
+  (let [{:keys [samples speed]} @posterior-sampling-state
+        amount (min speed (- maximum-posterior-samples (count samples)))
+        additions (vec (repeatedly amount #(weighted-grid-sample! @posterior-sampling-rng)))]
+    (swap! posterior-sampling-state update :samples into additions)))
+
+(declare posterior-sampling-tick!)
+
+(defn schedule-posterior-tick! []
+  (swap! posterior-sampling-state assoc
+         :timer (js/setTimeout posterior-sampling-tick! 1000)))
+
+(defn posterior-sampling-tick! []
+  (when (:running? @posterior-sampling-state)
+    (add-posterior-samples!)
+    (if (< (count (:samples @posterior-sampling-state)) maximum-posterior-samples)
+      (schedule-posterior-tick!)
+      (swap! posterior-sampling-state assoc :running? false :timer nil))))
+
+(defn reset-posterior-sampling! []
+  (cancel-posterior-timer!)
+  (reset! posterior-sampling-rng (make-rng posterior-draw-seed))
+  (let [speed (:speed @posterior-sampling-state)]
+    (reset! posterior-sampling-state
+            (assoc initial-posterior-sampling-state :speed speed))))
+
+(defn start-posterior-sampling! []
+  (when (= maximum-posterior-samples
+           (count (:samples @posterior-sampling-state)))
+    (reset-posterior-sampling!))
+  (cancel-posterior-timer!)
+  (swap! posterior-sampling-state assoc :running? true)
+  (posterior-sampling-tick!))
+
+(def posterior-bin-count 200)
+
+(defn posterior-histogram [samples]
+  (reduce (fn [counts sample]
+            (let [index (min (dec posterior-bin-count)
+                             (js/Math.floor (* posterior-bin-count sample)))]
+              (update counts index inc)))
+          (vec (repeat posterior-bin-count 0))
+          samples))
+
+(defn point-path [samples]
+  (let [sample-count (count samples)]
+    (str/join
+     " "
+     (map-indexed
+      (fn [index p]
+        (let [x (+ 50 (* index (/ 550 (max 1 (dec sample-count)))))
+              y (- 220 (* 176 p))]
+          (str "M" x " " y "l0.01 0")))
+      samples))))
+
+(defn posterior-trace-chart [samples title id]
+  [:figure.bp-chart
+   [:h4 title]
+   (if (seq samples)
+     [:svg {:view-box "0 0 640 285" :role "img"
+            :aria-labelledby (str id "-title " id "-desc")}
+      [:title {:id (str id "-title")} title]
+      [:desc {:id (str id "-desc")}
+       (str (count samples) " posterior samples plotted by draw number and water proportion.")]
+      (for [[p label] [[0 "0"] [0.25 ".25"] [0.5 ".50"] [0.75 ".75"] [1 "1"]]
+            :let [y (- 220 (* 176 p))]]
+        ^{:key p}
+        [:g
+         [:line.bp-guide {:x1 50 :x2 600 :y1 y :y2 y}]
+         [:text {:x 44 :y (+ y 4) :text-anchor "end" :font-size 11 :fill "currentColor"}
+          label]])
+      [:line.bp-axis {:x1 50 :x2 600 :y1 220 :y2 220}]
+      [:line.bp-axis {:x1 50 :x2 50 :y1 44 :y2 220}]
+      [:path.bp-points {:d (point-path samples)}]
+      [:text {:x 325 :y 272 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+       "Draw number"]]
+     [:div.bp-empty "Press Play to draw from the posterior."])])
+
+(defn posterior-count-chart [samples title id]
+  (let [counts (posterior-histogram samples)
+        maximum (apply max 1 counts)]
+    [:figure.bp-chart
+     [:h4 title]
+     (if (seq samples)
+       [:svg {:view-box "0 0 640 285" :role "img"
+              :aria-labelledby (str id "-title " id "-desc")}
+        [:title {:id (str id "-title")} title]
+        [:desc {:id (str id "-desc")}
+         (str (count samples) " posterior samples counted in 200 bins.")]
+        [:line.bp-axis {:x1 50 :x2 600 :y1 220 :y2 220}]
+        (for [[index count] (map-indexed vector counts)
+              :let [x (+ 50 (* index (/ 550 posterior-bin-count)))
+                    height (* 176 (/ count maximum))]]
+          ^{:key index}
+          [:rect {:x x :y (- 220 height)
+                  :width (max 1.2 (- (/ 550 posterior-bin-count) 0.2))
+                  :height height :fill "#2780e3" :fill-opacity 0.78}])
+        (for [[p label] [[0 "0"] [0.25 ".25"] [0.5 ".50"] [0.75 ".75"] [1 "1"]]
+              :let [x (+ 50 (* 550 p))]]
+          ^{:key p}
+          [:text {:x x :y 242 :text-anchor "middle" :font-size 11 :fill "currentColor"}
+           label])
+        [:text {:x 325 :y 272 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+         "Water proportion p"]]
+       [:div.bp-empty "The 200-bin count appears as samples accumulate."])]))
+
+(defn posterior-density-chart [samples title id]
+  (let [counts (posterior-histogram samples)
+        average (/ (max 1 (reduce + counts)) posterior-bin-count)
+        density (mapv #(/ % average) counts)]
+    [line-chart {:id id :title title
+                 :description (str (count samples) " posterior samples converted to a standardised 200-bin density.")
+                 :values density :x-label "Water proportion p" :y-label "Sample density"}]))
+
+(defn posterior-sample-panels [samples prefix id-prefix]
+  [:div.bp-grid
+   [posterior-trace-chart samples (str prefix " · trace") (str id-prefix "-trace")]
+   [posterior-count-chart samples (str prefix " · count in 200 bins") (str id-prefix "-count")]
+   [posterior-density-chart samples (str prefix " · standardised density") (str id-prefix "-density")]])
+
+(defn posterior-sampling-simulator []
+  (let [{:keys [samples speed running?]} @posterior-sampling-state
+        sample-count (count samples)
+        live-median (when (seq samples) (median samples))
+        direct-decision (first minimum-loss-pair)
+        dollar-loss (js/Math.round (* 100 (js/Math.abs (- 0.6 fixed-posterior-median))))]
+    [:section.bp-shell {:aria-labelledby "posterior-sampling-heading"}
+     [:h3#posterior-sampling-heading "Sample from the posterior"]
+     [:details.bp-details
+      [:summary "Question"]
+      [:div
+       [:p "Choose d, your estimate of the globe's water proportion. A perfect answer earns $100, with $1 subtracted for every 0.01 of absolute error. Which decision minimises expected loss?"]
+       [:p.bp-note "Adapted from Richard McElreath, Statistical Rethinking, section 3.2."]]]
+     [:p.bp-stat
+      (str "Seeded dataset: " (:water fixed-globe-counts) " water and "
+           (:land fixed-globe-counts) " land among 100 observations generated with true p = 0.6.")]
+     [:div.bp-grid
+      [proportion-chart fixed-globe-counts "posterior-data-bars"]
+      [line-chart {:id "fixed-posterior" :title "Posterior from 100 observations"
+                   :description "Grid posterior for the fixed set of 100 globe observations."
+                   :values fixed-posterior :x-label "Water proportion p" :y-label "Relative density"}]
+      [line-chart {:id "absolute-loss" :title (str "Expected absolute loss · minimum at d = " direct-decision)
+                   :description "Expected absolute loss across candidate decisions from zero to one."
+                   :values loss-values :x-label "Decision d" :y-label "Expected loss"}]]
+     [:p
+      "The direct grid calculation minimises expected loss at "
+      [:strong (format-decimal direct-decision 3)]
+      ". Theory says that absolute loss is also minimised by the posterior median. Draw from the posterior to watch that estimate settle."]
+     [:div.bp-controls
+      [control-button (if running? "Pause" "Play")
+       #(if running? (cancel-posterior-timer!) (start-posterior-sampling!))
+       {:class "bp-button bp-primary" :aria-pressed running?}]
+      [:label {:for "posterior-speed"} "Speed"]
+      [:select#posterior-speed.bp-select
+       {:value speed
+        :on-change #(swap! posterior-sampling-state assoc :speed
+                           (js/parseInt (.. % -target -value)))}
+       (for [option [1 5 10 50 100 200]]
+         ^{:key option}
+         [:option {:value option} (str option " samples/second")])]
+      [control-button "Clear samples" reset-posterior-sampling!
+       {:disabled (zero? sample-count)}]]
+     [:progress.bp-progress {:value sample-count :max maximum-posterior-samples
+                             :aria-label "Posterior samples completed"}]
+     [:p.bp-stat {:aria-live (if running? "off" "polite")}
+      [:strong (str sample-count " / " maximum-posterior-samples " animated samples")]
+      (when live-median
+        (str " · live median " (format-decimal live-median 3)))]
+     [posterior-sample-panels samples "Animated samples" "animated"]
+     [:h4 "Fixed 10,000-sample comparison"]
+     [:p.bp-stat
+      (str "Median = " (format-decimal fixed-posterior-median 6)
+           ". At $1 per 0.01 of error from the true p = 0.6, rounded loss = $"
+           dollar-loss "; final payoff = $" (- 100 dollar-loss) ".")]
+     [posterior-sample-panels fixed-ten-thousand-samples "10,000 samples" "fixed"]
+     [:p.bp-note "All posterior draws are discrete grid values spaced by 0.005. The 10,000-point trace is rendered as one SVG path, avoiding 10,000 DOM nodes while retaining every draw."]]))
+
+;; Simulation 3: sequential grid updating for Gaussian height parameters.
+
+(def adult-heights
+  [151.765 139.7 136.525 156.845 145.415 163.83 149.225 168.91 147.955
+   165.1 154.305 151.13 144.78 149.9 150.495 163.195 157.48 143.9418
+   161.29 156.21 146.4 148.59 147.32 147.955 161.925 146.05 146.05
+   152.7048 142.875 142.875 147.955 160.655 151.765 162.8648 171.45
+   147.32 147.955 154.305 143.51 146.7 157.48 165.735 152.4 141.605
+   158.8 155.575 164.465 151.765 161.29 154.305 145.415 145.415 152.4
+   163.83 144.145 153.67 142.875 167.005 158.4198 165.735 149.86 154.94
+   160.9598 161.925 147.955 159.385 148.59 136.525 158.115 144.78
+   156.845 179.07 170.18 146.05 147.32 162.56 152.4 160.02 149.86
+   142.875 167.005 159.385 154.94 162.56 152.4 170.18 146.05 159.385
+   151.13 160.655 169.545 158.75 149.86 153.035 161.925 162.56 149.225
+   163.195 161.925 145.415 163.195 151.13 150.495 170.815 157.48 152.4
+   147.32 145.415 157.48 154.305 167.005 142.875 152.4 160 159.385 149.86
+   160.655 160.655 149.225 140.97 154.94 141.605 160.02 150.1648 155.575
+   156.21 153.035 167.005 149.86 147.955 159.385 161.925 155.575 159.385
+   146.685 172.72 166.37 141.605 151.765 156.845 148.59 157.48 149.86
+   147.955 153.035 160.655 149.225 138.43 162.56 149.225 158.75 149.86
+   158.115 156.21 148.59 143.51 154.305 157.48 157.48 154.305 168.275
+   145.415 149.225 154.94 162.56 156.845 161.0106 144.78 143.51 149.225
+   149.86 165.735 144.145 157.48 154.305 163.83 156.21 144.145 162.56
+   146.05 154.94 144.78 146.685 152.4 163.83 165.735 156.21 152.4
+   140.335 163.195 151.13 171.1198 149.86 163.83 141.605 149.225 146.05
+   161.29 162.56 145.415 170.815 159.385 159.4 153.67 160.02 150.495
+   149.225 142.875 142.113 147.32 162.56 164.465 160.02 153.67 167.005
+   151.13 153.035 139.065 152.4 154.94 147.955 144.145 155.575 150.495
+   155.575 154.305 157.48 168.91 150.495 160.02 167.64 144.145 145.415
+   160.02 164.465 153.035 149.225 160.02 149.225 153.67 150.495 151.765
+   158.115 149.225 151.765 154.94 161.29 148.59 160.655 157.48 167.005
+   157.48 152.4 152.4 161.925 152.4 159.385 142.24 168.91 160.02 158.115
+   152.4 155.575 154.305 156.845 156.21 168.275 147.955 157.48 160.7
+   161.29 150.495 163.195 148.59 148.59 161.925 153.67 151.13 163.83
+   153.035 151.765 156.21 140.335 158.75 142.875 151.9428 161.29 160.9852
+   144.78 160.02 160.9852 165.989 157.988 154.94 160.655 147.32 146.7
+   147.32 172.9994 158.115 147.32 165.989 149.86 161.925 163.83 160.02
+   154.94 152.4 146.05 151.9936 151.765 144.78 160.655 151.13 153.67
+   147.32 139.7 157.48 154.94 143.51 158.115 147.32 160.02 165.1 154.94
+   153.67 141.605 163.83 161.29 154.9 161.3 170.18 149.86 160.655 154.94
+   166.37 148.2852 151.765 148.59 153.67 146.685 154.94 156.21 160.655
+   146.05 156.21 152.4 162.56 142.875 162.56 156.21 158.75])
+
+(def mean-grid (mapv #(+ 150 (* 0.25 %)) (range 41)))
+(def sd-grid (mapv #(+ 7 (* 0.05 %)) (range 41)))
+(def gaussian-grid
+  (vec (for [sd sd-grid
+             mean mean-grid]
+         {:mean mean :sd sd})))
+
+(defn normal-density [x mean sd]
+  (/ (js/Math.exp (/ (* -0.5 (js/Math.pow (- x mean) 2))
+                     (js/Math.pow sd 2)))
+     (* (js/Math.sqrt (* 2 js/Math.PI)) sd)))
+
+(def gaussian-prior
+  (normalize-mean-one
+   (mapv (fn [{:keys [mean]}]
+           (normal-density mean 178 20))
+         gaussian-grid)))
+
+(defonce gaussian-cache
+  (atom {:posteriors [gaussian-prior]
+         :likelihoods []}))
+
+(defn height-likelihood [height]
+  (normalize-mean-one
+   (mapv (fn [{:keys [mean sd]}]
+           (normal-density height mean sd))
+         gaussian-grid)))
+
+(defn ensure-gaussian-step! [target-posterior-count]
+  (loop []
+    (let [{:keys [posteriors likelihoods]} @gaussian-cache
+          observed-count (dec (count posteriors))]
+      (when (< observed-count target-posterior-count)
+        (let [likelihood (height-likelihood (nth adult-heights observed-count))
+              posterior (normalize-mean-one
+                         (mapv * (peek posteriors) likelihood))]
+          (reset! gaussian-cache
+                  {:posteriors (conj posteriors posterior)
+                   :likelihoods (conj likelihoods likelihood)})
+          (recur))))))
+
+(defn heat-opacity [value maximum]
+  (let [ratio (/ value (max maximum 1.0e-300))
+        intensity (/ (js/Math.log1p (* 999 ratio)) (js/Math.log 1000))]
+    (+ 0.035 (* 0.965 intensity))))
+
+(defn heat-map [{:keys [id title description values]}]
+  (let [maximum (apply max 1.0e-300 values)
+        cell-size 8]
+    [:figure.bp-chart
+     [:h4 title]
+     [:svg {:view-box "0 0 410 410" :role "img"
+            :aria-labelledby (str id "-title " id "-desc")}
+      [:title {:id (str id "-title")} title]
+      [:desc {:id (str id "-desc")} description]
+      (for [[index value] (map-indexed vector values)
+            :let [column (mod index 41)
+                  row (js/Math.floor (/ index 41))
+                  x (+ 54 (* column cell-size))
+                  y (+ 28 (* (- 40 row) cell-size))]]
+        ^{:key index}
+        [:rect {:x x :y y :width cell-size :height cell-size
+                :fill "#2780e3" :fill-opacity (heat-opacity value maximum)}])
+      [:rect {:x 54 :y 28 :width (* 41 cell-size) :height (* 41 cell-size)
+              :fill "none" :stroke "currentColor" :stroke-opacity 0.45}]
+      (for [[mean label] [[150 "150"] [155 "155"] [160 "160"]]
+            :let [x (+ 54 (* (- mean 150) (/ (* 40 cell-size) 10)))]]
+        ^{:key mean}
+        [:text {:x x :y 377 :text-anchor "middle" :font-size 11 :fill "currentColor"}
+         label])
+      (for [[sd label] [[7 "7"] [8 "8"] [9 "9"]]
+            :let [y (+ 34 (* (- 9 sd) (/ (* 40 cell-size) 2)))]]
+        ^{:key sd}
+        [:text {:x 47 :y y :text-anchor "end" :font-size 11 :fill "currentColor"}
+         label])
+      [:text {:x 218 :y 401 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+       "Mean μ (cm)"]
+      [:text {:x 12 :y 194 :transform "rotate(-90 12 194)"
+              :text-anchor "middle" :font-size 12 :fill "currentColor"}
+       "Standard deviation σ (cm)"]
+      (for [index (range 10)
+            :let [x (+ 297 (* index 9))]]
+        ^{:key index}
+        [:rect {:x x :y 386 :width 9 :height 8 :fill "#2780e3"
+                :fill-opacity (+ 0.035 (* 0.965 (/ index 9)))}])
+      [:text {:x 293 :y 393 :text-anchor "end" :font-size 9 :fill "currentColor"} "low"]
+      [:text {:x 390 :y 393 :font-size 9 :fill "currentColor"} "high"]]]))
+
+(def maximum-height-step (dec (count adult-heights)))
+(def initial-gaussian-state {:step 0 :speed 1.0 :running? false :timer nil})
+(defonce gaussian-state (r/atom initial-gaussian-state))
+
+(defn cancel-gaussian-timer! []
+  (when-let [timer (:timer @gaussian-state)]
+    (js/clearTimeout timer))
+  (swap! gaussian-state assoc :timer nil :running? false))
+
+(declare gaussian-tick!)
+
+(defn schedule-gaussian-tick! []
+  (swap! gaussian-state assoc
+         :timer (js/setTimeout gaussian-tick! (/ 1000 (:speed @gaussian-state)))))
+
+(defn gaussian-tick! []
+  (when (:running? @gaussian-state)
+    (if (< (:step @gaussian-state) maximum-height-step)
+      (do
+        (swap! gaussian-state update :step inc)
+        (schedule-gaussian-tick!))
+      (swap! gaussian-state assoc :running? false :timer nil))))
+
+(defn start-gaussian! []
+  (when (= (:step @gaussian-state) maximum-height-step)
+    (swap! gaussian-state assoc :step 0))
+  (cancel-gaussian-timer!)
+  (swap! gaussian-state assoc :running? true)
+  (schedule-gaussian-tick!))
+
+(defn gaussian-height-simulator []
+  (let [{:keys [step speed running?]} @gaussian-state
+        _ (ensure-gaussian-step! (inc step))
+        {:keys [posteriors likelihoods]} @gaussian-cache
+        before (nth posteriors step)
+        likelihood (nth likelihoods step)
+        after (nth posteriors (inc step))
+        height (nth adult-heights step)]
+    [:section.bp-shell {:aria-labelledby "gaussian-simulator-heading"}
+     [:h3#gaussian-simulator-heading "Update a Gaussian height model"]
+     [:details.bp-details
+      [:summary "Question"]
+      [:div
+       [:p "Every pair (μ, σ) defines a possible Gaussian distribution. Give each pair a prior plausibility, then use the observed heights to rank the pairs by posterior compatibility with the data and model."]
+       [:p.bp-note "Adapted from Richard McElreath, Statistical Rethinking, section 4.3."]]]
+     [:details.bp-details
+      [:summary "Prior"]
+      [:div
+       [:p "The grid is uniform over σ from 7 to 9 cm. Across μ from 150 to 160 cm, prior weight follows a Normal(178, 20) density."]
+       [heat-map {:id "gaussian-prior" :title "Prior · μ ~ Normal(178, 20)"
+                  :description "Prior plausibility over the 41 by 41 grid of mean and standard-deviation values."
+                  :values gaussian-prior}]]]
+     [:div.bp-controls
+      [control-button (if running? "Pause" "Play")
+       #(if running? (cancel-gaussian-timer!) (start-gaussian!))
+       {:class "bp-button bp-primary" :aria-pressed running?}]
+      [:label {:for "gaussian-speed"} "Speed"]
+      [:input#gaussian-speed
+       {:type "range" :min 0.5 :max 10 :step 0.5 :value speed
+        :on-change #(swap! gaussian-state assoc :speed
+                           (js/parseFloat (.. % -target -value)))}]
+      [:span (str (counted-label speed "height") "/second")]
+      [control-button "Previous"
+       #(swap! gaussian-state update :step (fn [current] (max 0 (dec current))))
+       {:disabled (zero? step)}]
+      [control-button "Next"
+       #(swap! gaussian-state update :step (fn [current] (min maximum-height-step (inc current))))
+       {:disabled (= step maximum-height-step)}]
+      [control-button "Clear" #(do (cancel-gaussian-timer!)
+                                   (swap! gaussian-state assoc :step 0))
+       {:disabled (zero? step)}]]
+     [:p.bp-stat {:aria-live (if running? "off" "polite")}
+      [:strong (str "Height " (inc step) " of " (count adult-heights) ": " height " cm. ")]
+      (str "Left: posterior after " (counted-label step "height")
+           ". Right: posterior after " (counted-label (inc step) "height") ".")]
+     [:div.bp-heat-grid
+      [heat-map {:id "posterior-before-height" :title (str "Posterior after " (counted-label step "height"))
+                 :description (str "Posterior plausibility over mean and standard deviation after " (counted-label step "observed height") ".")
+                 :values before}]
+      [heat-map {:id "current-height-likelihood" :title (str "Likelihood of height " height " cm")
+                 :description (str "Relative Gaussian likelihood of the current height, " height " centimetres, over the parameter grid.")
+                 :values likelihood}]
+      [heat-map {:id "posterior-after-height" :title (str "Posterior after " (counted-label (inc step) "height"))
+                 :description (str "Updated posterior after multiplying by the likelihood of height " height " centimetres and normalising.")
+                 :values after}]]
+     [:p.bp-note "Each map contains all 1,681 (μ, σ) candidates. Colour opacity uses a logarithmic scale within that panel; compare location and concentration, not absolute colour between panels."]]))
+
+(defn ^:export mount []
+  (when-let [root (js/document.getElementById "globe-update-simulator")]
+    (rdom/render [globe-update-simulator] root))
+  (when-let [root (js/document.getElementById "posterior-sampling-simulator")]
+    (rdom/render [posterior-sampling-simulator] root))
+  (when-let [root (js/document.getElementById "gaussian-height-simulator")]
+    (rdom/render [gaussian-height-simulator] root)))
+
+(if (= "loading" js/document.readyState)
+  (.addEventListener js/document "DOMContentLoaded" mount)
+  (mount))

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
@@ -18,6 +18,39 @@
  [:style
   "#title-block-header{padding-top:.75rem}#title-block-header h1{line-height:1.15;overflow-wrap:anywhere}.ve-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.25rem}.ve-callout.provisional{border-color:#e69f00;background:#fff8e6}.ve-callout strong{display:block;margin-bottom:.3rem}.ve-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}.ve-card{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:1rem;background:var(--bs-body-bg,#fff)}.ve-card h3{font-size:1rem;margin-top:0}.ve-table-wrap{overflow-x:auto;margin:1.25rem 0}.ve-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}.ve-table th,.ve-table td{padding:.55rem .7rem;border-bottom:1px solid #dee2e6;text-align:right;white-space:nowrap}.ve-table th:first-child,.ve-table td:first-child{text-align:left}.ve-table thead th{border-bottom:2px solid #adb5bd}.ve-figure{margin:1.5rem 0;padding:1rem;border:1px solid #dee2e6;border-radius:.5rem}.ve-figure svg{display:block;width:100%;height:auto}.ve-caption{font-size:.9rem;color:var(--bs-secondary-color,#5c636a);margin:.75rem 0 0}.ve-simulator{margin:1.5rem 0}.ve-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}@media(max-width:575px){.ve-table th,.ve-table td{padding:.45rem}.ve-figure{padding:.65rem}}"])
 
+^:kindly/hide-code
+(kind/hiccup
+ [:style
+  ".series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--bs-secondary-color,#5c636a)}"])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:nav.series-toc {:aria-labelledby "series-contents-heading"}
+  [:h2#series-contents-heading "Series contents"]
+  [:p
+   [:strong "Revisiting basic Bayes' theorem and applying it to a real word problem: estimating vocabulary size from "]
+   [:a {:href "https://lexibench.com/"} "Lexibench.com"]
+   [:strong " quiz responses."]]
+  [:ol
+   [:li [:a {:href "bayes_theorem_simulations.html"}
+         "Bayes' Theorem, Revisited: Three Interactive Simulations"]
+    [:span.series-status "published"]]
+   [:li [:a {:href "beta_binomial_first_pass.html"}
+         "Estimating Vocabulary Size with a Simple Bayesian Model"]
+    [:span.series-status "published"]]
+   [:li "Does Pair Frequency Predict Learner Responses?"
+    [:span.series-status "planned"]]
+   [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
+    [:span.series-status "planned"]]
+   [:li "From Correlated Form Pairs to Latent Lemma Knowledge"
+    [:span.series-status "planned"]]
+   [:li "Modelling Correct, Wrong, and Don't-Know Separately"
+    [:span.series-status "planned"]]
+   [:li "Calibrating Items Before IRT and Adaptive Selection"
+    [:span.series-status "planned"]]
+   [:li "When Contexts and Senses Become Identifiable"
+    [:span.series-status "planned"]]]])
+
 ;; I am building [**Lexibench**](https://lexibench.com/), a vocabulary-testing
 ;; product. Much of its user interface is already in place, but its scorer is
 ;; being replaced. The model in this post is a deliberately small first pass: it

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
@@ -183,9 +183,7 @@
  [:div.ve-simulator
   [:div#beta-binomial-simulator
    [:p "Loading the Bayesian update simulator…"]]
-  [:noscript "This simulator needs JavaScript. The statistical core above remains readable without it."]
-  [:script {:type "application/x-scittle"
-            :src "beta_binomial_first_pass_interactive.cljs"}]])
+  [:noscript "This simulator needs JavaScript. The statistical core above remains readable without it."]])
 
 ;; ## From a knowing rate to a vocabulary total
 ;;
@@ -325,6 +323,36 @@ worked-analytic-mean
     "3,404 — 4,334 — 5,249"]]
   [:figcaption.ve-caption
    "Blue: central 95% credible interval. Red: posterior-predictive mean. Scale: pairs known in the fixed 8,000-pair pool."]])
+
+;; ### Watch complete posterior-predictive draws accumulate
+;;
+;; One **complete draw** below passes through all eight strata. In each stratum
+;; it draws a knowing rate from that stratum's Beta posterior, predicts the
+;; known count among its 996 untested pairs, adds the observed correct pairs,
+;; and finally sums the eight counts.
+;;
+;; The first view exposes the newest complete draw rather than showing only its
+;; total. The second retains every complete draw as one dot. Its live mean and
+;; interval therefore use exactly the dots you can see—none are hidden in an
+;; aggregate. Choose 10, 20, or 50 draws per second; changing speed does not
+;; change the seeded sequence.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:style
+  ".ve-posterior-sampler{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.ve-sampling-intro{max-width:50rem}.ve-sampling-controls{display:flex;align-items:end;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin:1rem 0}.ve-rate-fieldset{border:0;padding:0;margin:0;min-width:0}.ve-rate-fieldset legend{font-size:.85rem;font-weight:700;margin-bottom:.4rem}.ve-button-row{display:flex;gap:.5rem;flex-wrap:wrap}.ve-sampling-button{border:1px solid #6c757d;border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-sampling-button[aria-pressed=true],.ve-sampling-button.ve-primary{border-color:#2780e3;background:#2780e3;color:#fff}.ve-sampling-button:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 45%,transparent);outline-offset:2px}.ve-sampling-progress{width:100%;height:.55rem;accent-color:#2780e3}.ve-sampling-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1rem;margin-top:1rem}.ve-sample-panel{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:clamp(.65rem,2vw,1rem);margin:0}.ve-sample-panel h4{font-size:1rem;margin:0 0 .25rem}.ve-sample-panel svg{display:block;width:100%;height:auto}.ve-sample-stat{font-variant-numeric:tabular-nums;margin:.2rem 0 .65rem}.ve-sample-note{font-size:.85rem;color:var(--bs-secondary-color,#5c636a);margin:.5rem 0 0}.ve-empty-sample{display:grid;place-items:center;min-height:13rem;border:1px dashed #adb5bd;border-radius:.35rem;color:var(--bs-secondary-color,#5c636a);text-align:center;padding:1rem}.ve-sampling-status{font-variant-numeric:tabular-nums;margin:.4rem 0}.ve-dot{fill:#2780e3;fill-opacity:.72}.ve-dot-latest{fill:#c44536;stroke:var(--bs-body-bg,#fff);stroke-width:1.5}.ve-sample-axis{stroke:currentColor;stroke-opacity:.45}.ve-sample-guide{stroke:currentColor;stroke-opacity:.1}.ve-latest-line{stroke:#2780e3;stroke-width:5;stroke-linecap:round}.ve-latest-dot{fill:#c44536;stroke:var(--bs-body-bg,#fff);stroke-width:2}@media(max-width:575px){.ve-sampling-controls{align-items:stretch}.ve-sampling-controls>.ve-button-row{width:100%}.ve-sampling-controls>.ve-button-row .ve-sampling-button{flex:1}.ve-sampling-button{padding:.55rem .7rem}}"])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.ve-simulator
+  [:div#posterior-sampling-simulator
+   [:p "Loading the posterior-predictive sampling simulator…"]]
+  [:noscript "This simulator needs JavaScript. The seeded numerical check below remains available without it."]
+  [:script {:type "application/x-scittle"
+            :src "beta_binomial_first_pass_interactive.cljs"}]])
+
+;; The 500 browser draws are for seeing the mechanism, not for replacing the
+;; larger verification run. Early live intervals are especially noisy.
 
 ;; ### A seeded numerical check
 ;;

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
@@ -303,7 +303,7 @@ worked-analytic-mean
 ^:kindly/hide-code
 (kind/hiccup
  [:figure.ve-figure
-  [:svg {:viewBox "0 0 800 150"
+  [:svg {:viewBox "-24 -24 848 198"
          :role "img"
          :aria-labelledby "worked-ci-title worked-ci-desc"}
    [:title#worked-ci-title "Worked-example posterior mean and 95 percent credible interval"]

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass_interactive.cljs
@@ -11,6 +11,21 @@
 
 (defonce state (r/atom initial-state))
 
+(def worked-correct-counts [4 4 3 3 2 1 1 0])
+(def sampling-target 500)
+(def sampling-seed 20260712)
+
+(def worked-sampling-strata
+  (mapv (fn [index k]
+          {:index (inc index)
+           :pool-size 1000
+           :k k
+           :n 4
+           :alpha (inc k)
+           :beta (inc (- 4 k))})
+        (range)
+        worked-correct-counts))
+
 (defn log-factorial [n]
   (reduce + 0 (map #(js/Math.log %) (range 2 (inc n)))))
 
@@ -130,6 +145,310 @@
                     :color "var(--bs-body-color, #212529)"}}
    label])
 
+(defn make-rng [seed]
+  #js {:state (mod seed 2147483647)})
+
+(defn uniform! [rng]
+  (let [next-state (mod (* 48271 (.-state rng)) 2147483647)]
+    (set! (.-state rng) next-state)
+    (/ (dec next-state) 2147483646.0)))
+
+(defn sample-integer-beta!
+  "Exact Beta draw for positive integer parameters, using an order statistic."
+  [rng alpha beta]
+  (->> (repeatedly (dec (+ alpha beta)) #(uniform! rng))
+       sort
+       (drop (dec alpha))
+       first))
+
+(defn sample-low-p-binomial! [rng trials p]
+  (let [q (- 1 p)
+        u (uniform! rng)]
+    (loop [x 0
+           probability (js/Math.pow q trials)
+           cumulative (js/Math.pow q trials)]
+      (if (or (>= cumulative u) (= x trials))
+        x
+        (let [next-x (inc x)
+              next-probability (* probability
+                                  (/ (* (- (inc trials) next-x) p)
+                                     (* next-x q)))]
+          (recur next-x
+                 next-probability
+                 (+ cumulative next-probability)))))))
+
+(defn sample-binomial! [rng trials p]
+  (if (> p 0.5)
+    (- trials (sample-low-p-binomial! rng trials (- 1 p)))
+    (sample-low-p-binomial! rng trials p)))
+
+(defn sample-stratum! [rng {:keys [pool-size k n alpha beta] :as stratum}]
+  (let [p (sample-integer-beta! rng alpha beta)]
+    (assoc stratum
+           :p p
+           :known (+ k (sample-binomial! rng (- pool-size n) p)))))
+
+(defn sample-complete-draw! [rng]
+  (let [strata (mapv #(sample-stratum! rng %) worked-sampling-strata)]
+    {:strata strata
+     :total (reduce + (map :known strata))}))
+
+(defn fresh-sampling-state
+  ([] (fresh-sampling-state 20))
+  ([rate]
+   {:status :idle
+    :rate rate
+    :draws []
+    :latest nil
+    :rng (make-rng sampling-seed)}))
+
+(defonce sampling-state (r/atom (fresh-sampling-state)))
+(defonce animation-frame-id (atom nil))
+(defonce animation-clock #js {:last nil :carry 0})
+
+(defn reset-animation-clock! []
+  (set! (.-last animation-clock) nil)
+  (set! (.-carry animation-clock) 0))
+
+(defn cancel-animation! []
+  (when-let [frame-id @animation-frame-id]
+    (js/cancelAnimationFrame frame-id)
+    (reset! animation-frame-id nil)))
+
+(declare animation-step!)
+
+(defn schedule-animation! []
+  (reset! animation-frame-id (js/requestAnimationFrame animation-step!)))
+
+(defn animation-step! [timestamp]
+  (when (= :running (:status @sampling-state))
+    (let [{:keys [rate draws rng]} @sampling-state
+          previous-time (or (.-last animation-clock) timestamp)
+          elapsed (min 250 (- timestamp previous-time))
+          budget (+ (.-carry animation-clock) (* elapsed (/ rate 1000.0)))
+          remaining (- sampling-target (count draws))
+          due (min remaining (long (js/Math.floor budget)))]
+      (set! (.-last animation-clock) timestamp)
+      (set! (.-carry animation-clock) (- budget due))
+      (when (pos? due)
+        (let [new-draws (vec (repeatedly due #(sample-complete-draw! rng)))
+              all-draws (into draws new-draws)
+              complete? (= sampling-target (count all-draws))]
+          (swap! sampling-state assoc
+                 :draws all-draws
+                 :latest (peek all-draws)
+                 :status (if complete? :complete :running))))
+      (if (= :running (:status @sampling-state))
+        (schedule-animation!)
+        (reset! animation-frame-id nil)))))
+
+(defn start-sampling! []
+  (when (= :complete (:status @sampling-state))
+    (let [rate (:rate @sampling-state)]
+      (reset! sampling-state (fresh-sampling-state rate))))
+  (cancel-animation!)
+  (reset-animation-clock!)
+  (swap! sampling-state assoc :status :running)
+  (schedule-animation!))
+
+(defn pause-sampling! []
+  (cancel-animation!)
+  (swap! sampling-state assoc :status :paused))
+
+(defn toggle-sampling! []
+  (if (= :running (:status @sampling-state))
+    (pause-sampling!)
+    (start-sampling!)))
+
+(defn reset-sampling! []
+  (let [rate (:rate @sampling-state)]
+    (cancel-animation!)
+    (reset-animation-clock!)
+    (reset! sampling-state (fresh-sampling-state rate))))
+
+(defn set-sampling-rate! [rate]
+  (swap! sampling-state assoc :rate rate))
+
+(def number-formatter (js/Intl.NumberFormat. "en-US"))
+
+(defn format-count [number]
+  (.format number-formatter number))
+
+(defn format-rate [p]
+  (str (.toFixed (* 100 p) 1) "%"))
+
+(defn sample-quantile [totals probability]
+  (let [ordered (vec (sort totals))
+        index (long (js/Math.floor (* probability (dec (count ordered)))))]
+    (nth ordered index)))
+
+(defn sampling-summary [draws]
+  (when (seq draws)
+    (let [totals (mapv :total draws)]
+      {:mean (/ (reduce + totals) (count totals))
+       :lower (sample-quantile totals 0.025)
+       :upper (sample-quantile totals 0.975)})))
+
+(defn x-for-stratum-count [known]
+  (+ 132 (* known (/ 500 1000.0))))
+
+(defn x-for-total [total]
+  (+ 60 (* total (/ 600 8000.0))))
+
+(defn latest-draw-chart [latest draw-number]
+  [:figure.ve-sample-panel
+   [:h4 "Newest complete draw"]
+   (if latest
+     [:div
+      [:p.ve-sample-stat
+       [:strong (str "Draw " draw-number ": " (format-count (:total latest)) " pairs total")]
+       " — eight stratum draws shown below."]
+      [:svg {:view-box "0 0 720 356"
+             :role "img"
+             :aria-labelledby "latest-draw-title latest-draw-desc"}
+       [:title#latest-draw-title "Newest complete posterior-predictive draw by stratum"]
+       [:desc#latest-draw-desc
+        (str "Draw " draw-number " totals " (:total latest)
+             " known pairs. Eight rows show the posterior rate and predicted known count for each 1,000-pair stratum.")]
+       (for [known [0 250 500 750 1000]
+             :let [x (x-for-stratum-count known)]]
+         ^{:key known}
+         [:g
+          [:line.ve-sample-guide {:x1 x :x2 x :y1 28 :y2 305}]
+          [:text {:x x :y 329 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+           known]])
+       (for [{:keys [index p known]} (:strata latest)
+             :let [y (+ 27 (* index 34))
+                   x (x-for-stratum-count known)]]
+         ^{:key index}
+         [:g
+          [:text {:x 18 :y (+ y 4) :font-size 13 :font-weight 700 :fill "currentColor"}
+           (str "S" index)]
+          [:line.ve-sample-axis {:x1 132 :x2 632 :y1 y :y2 y}]
+          [:line.ve-latest-line {:x1 132 :x2 x :y1 y :y2 y}]
+          [:circle.ve-latest-dot {:cx x :cy y :r 6}]
+          [:text {:x 704 :y (+ y 4) :text-anchor "end" :font-size 12 :fill "currentColor"}
+           (str (format-rate p) " → " known)]])
+       [:text {:x 382 :y 350 :text-anchor "middle" :font-size 13 :fill "currentColor"}
+        "Known pairs in each 1,000-pair stratum"]]
+      [:figcaption.ve-sample-note
+       "Each row shows p drawn from that stratum's Beta posterior, then the resulting finite-pool known count (observed correct + simulated untested known)."]]
+     [:div.ve-empty-sample
+      "Press Start to reveal each complete eight-stratum draw."])])
+
+(def dot-bin-count 80)
+
+(defn dot-positions [draws]
+  (let [bin-counts (atom {})]
+    (mapv (fn [[index {:keys [total]}]]
+            (let [bin (min (dec dot-bin-count)
+                           (long (js/Math.floor (* dot-bin-count (/ total 8000.0)))))
+                  level (get @bin-counts bin 0)]
+              (swap! bin-counts update bin (fnil inc 0))
+              {:index index
+               :x (x-for-total total)
+               :y (- 228 (* level 4.1))}))
+          (map-indexed vector draws))))
+
+(defn all-draws-chart [draws]
+  (let [summary (sampling-summary draws)
+        positions (dot-positions draws)
+        draw-count (count draws)]
+    [:figure.ve-sample-panel
+     [:h4 "Every complete draw used"]
+     (if summary
+       [:div
+        [:p.ve-sample-stat
+         [:strong (str draw-count " / " sampling-target " dots")]
+         (str " · mean " (format-count (js/Math.round (:mean summary)))
+              " · live 95% equal-tail interval "
+              (format-count (:lower summary)) "–" (format-count (:upper summary)))]
+        [:svg {:view-box "0 0 720 286"
+               :role "img"
+               :aria-labelledby "all-draws-title all-draws-desc"}
+         [:title#all-draws-title "All complete posterior-predictive draws"]
+         [:desc#all-draws-desc
+          (str draw-count " complete draws are shown, one dot each. Their mean is "
+               (js/Math.round (:mean summary)) " and their current 95 percent equal-tail interval is "
+               (:lower summary) " to " (:upper summary) ".")]
+         (for [total [0 2000 4000 6000 8000]
+               :let [x (x-for-total total)]]
+           ^{:key total}
+           [:g
+            [:line.ve-sample-guide {:x1 x :x2 x :y1 22 :y2 232}]
+            [:text {:x x :y 258 :text-anchor "middle" :font-size 12 :fill "currentColor"}
+             (format-count total)]])
+         [:line.ve-sample-axis {:x1 60 :x2 660 :y1 232 :y2 232}]
+         (when (> draw-count 1)
+           [:line {:x1 (x-for-total (:lower summary))
+                   :x2 (x-for-total (:upper summary))
+                   :y1 16 :y2 16 :stroke "#2780e3" :stroke-width 8
+                   :stroke-linecap "round"}])
+         (when (> draw-count 1)
+           [:circle {:cx (x-for-total (:mean summary)) :cy 16 :r 6
+                     :fill "#c44536" :stroke "white" :stroke-width 1.5}])
+         (for [{:keys [index x y]} positions]
+           ^{:key index}
+           [:circle {:class (if (= index (dec draw-count)) "ve-dot-latest" "ve-dot")
+                     :cx x :cy y :r (if (= index (dec draw-count)) 3.8 2.4)}])
+         [:text {:x 360 :y 281 :text-anchor "middle" :font-size 13 :fill "currentColor"}
+          "Total known pairs in the fixed 8,000-pair pool"]]
+        [:figcaption.ve-sample-note
+         "One dot is one complete eight-stratum draw. Blue line: live central 95% interval. Red marker: live sample mean. Both stabilize as dots accumulate."]]
+       [:div.ve-empty-sample
+        "All complete draws will remain visible here, one dot per draw."])]))
+
+(defn rate-button [rate selected-rate]
+  [:button {:type "button"
+            :class (str "ve-sampling-button ve-rate-" rate)
+            :aria-pressed (= rate selected-rate)
+            :on-click #(set-sampling-rate! rate)}
+   (str rate "/s")])
+
+(defn sampling-status-text [status draw-count]
+  (case status
+    :running (str "Running: " draw-count " of " sampling-target " complete draws.")
+    :paused (str "Paused after " draw-count " of " sampling-target " complete draws.")
+    :complete (str "Complete: all " sampling-target " draws are visible.")
+    (str "Ready: 0 of " sampling-target " complete draws.")))
+
+(defn posterior-sampling-simulator []
+  (let [{:keys [status rate draws latest]} @sampling-state
+        draw-count (count draws)
+        running? (= status :running)]
+    [:section.ve-posterior-sampler {:aria-labelledby "posterior-sampler-heading"}
+     [:div.ve-sampling-intro
+      [:h3#posterior-sampler-heading {:style {:margin-top 0}}
+       "Posterior-predictive sampling, one complete draw at a time"]
+      [:p
+       "The deterministic seed fixes the sequence. Speed changes only how quickly the same 500 complete draws appear."]]
+     [:div.ve-sampling-controls
+      [:fieldset.ve-rate-fieldset
+       [:legend "Complete samples per second"]
+       [:div.ve-button-row
+        [rate-button 10 rate]
+        [rate-button 20 rate]
+        [rate-button 50 rate]]]
+      [:div.ve-button-row
+       [:button {:type "button"
+                 :class "ve-sampling-button ve-primary ve-sampling-toggle"
+                 :on-click toggle-sampling!}
+        (cond
+          running? "Pause"
+          (= status :complete) "Run again"
+          :else "Start")]
+       [:button {:type "button"
+                 :class "ve-sampling-button ve-sampling-reset"
+                 :on-click reset-sampling!}
+        "Reset"]]]
+     [:progress.ve-sampling-progress {:value draw-count :max sampling-target
+                                      :aria-label "Posterior-predictive samples completed"}]
+     [:p.ve-sampling-status {:aria-live (if running? "off" "polite")}
+      (sampling-status-text status draw-count)]
+     [:div.ve-sampling-grid
+      [latest-draw-chart latest draw-count]
+      [all-draws-chart draws]]]))
+
 (defn simulator []
   (let [{:keys [alpha beta responses] :as current} @state
         n (count responses)
@@ -161,6 +480,10 @@
 
 (defn ^:export mount []
   (when-let [root (js/document.getElementById "beta-binomial-simulator")]
-    (rdom/render [simulator] root)))
+    (rdom/render [simulator] root))
+  (when-let [root (js/document.getElementById "posterior-sampling-simulator")]
+    (rdom/render [posterior-sampling-simulator] root)))
 
-(mount)
+(if (= "loading" js/document.readyState)
+  (.addEventListener js/document "DOMContentLoaded" mount)
+  (mount))


### PR DESCRIPTION
## Summary

- publish ‘Bayes’ Theorem, Revisited: Three Interactive Simulations’ as the first article in the Bayes-to-Lexibench series
- recreate the globe update, posterior-sampling decision, and Gaussian-height simulations with Kindly, Scittle, Reagent, deterministic seeds, and accessible responsive SVG
- make the implementation-change notes collapsible
- add the same numbered series table of contents to this new article and the previous ‘Estimating Vocabulary Size with a Simple Bayesian Model’ article
- link the two published posts and Lexibench.com while leaving six planned posts unlinked
- retain the previous article’s seeded posterior-predictive sampling visualization

Future posts are tracked in #407.

## Verification

- clj-paren-repair on both article sources and the interactive ClojureScript
- executable assertions pass for both articles
- Clay renders pass for both articles
- targeted Quarto HTML renders pass for both articles
- browser checks cover Scittle mounting and controls, pointer and Enter/Space interaction, collapsible notes, accessible labels and SVG descriptions, dark theme, and mobile layout without overflow
- browser console has no application errors

The repository-wide Quarto render still reaches an existing PDF target that requires TeX; both affected article targets render successfully.