### PR TITLE
Publish the Bayes-to-Lexibench vocabulary-estimation series

### DIFF
--- a/clay.edn
+++ b/clay.edn
@@ -1,5 +1,9 @@
 {:base-target-path   "temp"
  :base-source-path   "src"
+ :watch-dirs         ["src"]
+ :format             [:quarto :html]
+ :run-quarto         true
+ :browse             false
  :quarto-target-path "site"
  :quarto             ^:replace {}
  :subdirs-to-sync    ["src"]

--- a/deps.edn
+++ b/deps.edn
@@ -91,7 +91,7 @@
  :aliases
  {;; Build the site with `clojure -M:clay -A:markdown`
   ;; Run Clay in watch mode with `clojure -M:clay`
-  :clay       {:main-opts ["-m" "scicloj.clay.v2.main"]
+  :clay       {:main-opts ["-m" "civitas.clay-main"]
                :jvm-opts  ["-Dclojure.main.report=stderr"
                            "--add-opens=java.base/java.nio=ALL-UNNAMED"]}
   ;; When debugging libraries

--- a/src/civitas/clay_main.clj
+++ b/src/civitas/clay_main.clj
@@ -1,0 +1,55 @@
+(ns civitas.clay-main
+  (:gen-class)
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [ring.util.mime-type :as mime-type]
+            [scicloj.clay.v2.main :as clay-main]
+            [scicloj.clay.v2.server :as clay-server]
+            [scicloj.clay.v2.server.state :as server-state])
+  (:import (java.io File)))
+
+(def default-preview-source
+  "language_learning/vocabulary_estimation/bayes_theorem_simulations.clj")
+
+(def preview-root "temp")
+(def published-root "site/_site")
+
+(defn- regular-file-under [root uri]
+  (when (and (string? uri) (str/starts-with? uri "/"))
+    (let [root-file (.getCanonicalFile (io/file root))
+          file (.getCanonicalFile (io/file root-file (subs uri 1)))
+          root-prefix (str (.getPath root-file) File/separator)]
+      (when (and (str/starts-with? (.getPath file) root-prefix)
+                 (.isFile file))
+        file))))
+
+(defn- current-preview-uri []
+  (let [{:keys [base-target-path full-target-path]}
+        (:last-rendered-spec @server-state/*state)]
+    (when (and base-target-path full-target-path)
+      (str "/" (clay-server/relative-url-path base-target-path
+                                              full-target-path)))))
+
+(defn preview-fallback-handler [{:keys [request-method uri]}]
+  (let [preview-file (regular-file-under preview-root uri)
+        linked-html? (and (str/ends-with? uri ".html")
+                          (not= uri (current-preview-uri)))]
+    (when (and (= :get request-method)
+               (or (nil? preview-file) linked-html?))
+      (when-let [file (regular-file-under published-root uri)]
+        {:status 200
+         :headers {"Content-Type"
+                   (or (mime-type/ext-mime-type uri)
+                       "application/octet-stream")}
+         :body (if (str/ends-with? uri ".html")
+                 (clay-server/wrap-html (slurp file) @server-state/*state)
+                 file)}))))
+
+(defn args-with-default-source [args]
+  (if (seq args)
+    args
+    [default-preview-source]))
+
+(defn -main [& args]
+  (clay-server/install-handler! #'preview-fallback-handler)
+  (apply clay-main/-main (args-with-default-source args)))

--- a/src/civitas/db.clj
+++ b/src/civitas/db.clj
@@ -3,16 +3,17 @@
   (:require [clojure.edn :as edn]
             [clojure.pprint :as pprint]
             [clojure.walk :as walk]
+            [scicloj.kindly.v4.api :as kindly]
             [tablecloth.api :as tc]
             [clj-yaml.core :as yaml]))
 
 (defn quarto []
   (walk/postwalk
-    (fn [x]
-      (cond (map? x) (into {} x)
-            (seq? x) (into [] x)
-            :else x))
-    (yaml/parse-string (slurp "site/_quarto.yml"))))
+   (fn [x]
+     (cond (map? x) (into {} x)
+           (seq? x) (into [] x)
+           :else x))
+   (yaml/parse-string (slurp "site/_quarto.yml"))))
 
 (def db-file "site/db.edn")
 
@@ -28,10 +29,10 @@
   "Return a map where a key is (f item) and a value is item."
   [f coll]
   (persistent!
-    (reduce
-      (fn [ret x]
-        (assoc! ret (f x) x))
-      (transient {}) coll)))
+   (reduce
+    (fn [ret x]
+      (assoc! ret (f x) x))
+    (transient {}) coll)))
 
 (defn author-replacements
   "Creates a map of author and affiliation keys to their full definition"
@@ -40,10 +41,29 @@
       (->> (index-by :id))
       (update-vals #(dissoc % :id))))
 
+(defn- ns-clay-config [ns-form]
+  (let [[_ sym ?doc ?attr] ns-form]
+    (kindly/deep-merge
+     (some-> ns-form meta :clay)
+     (some-> sym meta :clay)
+     (:clay (cond
+              (map? ?doc) ?doc
+              (map? ?attr) ?attr)))))
+
+(defn- restore-replaced-quarto-config [config]
+  (let [quarto (:quarto config)
+        ns-quarto (some-> config :ns-form ns-clay-config :quarto)]
+    (if (and ns-quarto (-> quarto meta :replace))
+      (assoc config :quarto
+             (kindly/deep-merge ns-quarto (with-meta quarto nil)))
+      config)))
+
 (defn expand-authors
   "Hook for Clay to update ns metadata configuration"
   [config]
-  (update config :quarto #(walk/prewalk-replace (author-replacements) %)))
+  (-> config
+      restore-replaced-quarto-config
+      (update :quarto #(walk/prewalk-replace (author-replacements) %))))
 
 ;; TODO: what if the front matter doesn't match existing?
 

--- a/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
+++ b/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
@@ -68,13 +68,32 @@
    ".bp-definition{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.75rem;background:var(--bs-body-bg,#fff)}"
    ".bp-definition dt{font-weight:800;color:var(--bp-accent)}.bp-definition dd{margin:.25rem 0 0}"
    ".bp-engineering-caption{text-align:center;color:var(--bp-muted);font-size:.88rem}"
-   ".series-toc{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}"
-   ".series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}"
+   ".series-toc{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:0 0 1.4rem;background:var(--bs-body-bg,#fff)}"
+   ".series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem .45rem}"
    ".series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--bp-muted)}"
+   ".series-current{margin:.35rem 0 .35rem -.7rem;border-left:4px solid var(--bp-accent);border-radius:.4rem;padding:.6rem .75rem!important;background:color-mix(in srgb,var(--bs-body-bg,#fff) 84%,var(--bp-accent) 16%);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--bp-accent) 35%,transparent);font-weight:700}.series-current>a{color:var(--bp-accent)}.series-current .series-status{border-radius:999px;padding:.18rem .48rem;background:var(--bp-accent);color:#fff}.quarto-dark .series-current .series-status{color:#10212b}"
    "@media(max-width:767px){.bp-process-strip{grid-template-columns:minmax(0,1fr)}.bp-process-symbol{min-height:1.2rem}.bp-shell{padding:.75rem}.bp-controls{align-items:stretch}.bp-button{flex:1}.bp-chart{padding:.5rem}}")])
 
 ^:kindly/hide-code
 (math/styles)
+
+^:kindly/hide-code
+(kind/hiccup
+ [:nav.series-toc {:aria-labelledby "series-contents-heading"}
+  [:h2#series-contents-heading "Bayes-to-Lexibench series"]
+  [:p "This article supplies the probability tools used by the later vocabulary-estimation articles."]
+  [:ol
+   [:li.series-current
+    [:a {:href "bayes_theorem_simulations.html" :aria-current "page"}
+     "Bayes' theorem from uncertainty to decision"]
+    [:span.series-status "you are here"]]
+   [:li [:a {:href "beta_binomial_first_pass.html"} "Estimating vocabulary size with a simple Bayesian model"] [:span.series-status "published"]]
+   [:li [:a {:href "pair_frequency_logistic_v2_article.html"} "Does pair frequency predict learner responses?"] [:span.series-status "published"]]
+   [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool" [:span.series-status "planned"]]
+   [:li "From Correlated Form Pairs to Latent Lemma Knowledge" [:span.series-status "planned"]]
+   [:li "Modelling Correct, Wrong, and Don't-Know Separately" [:span.series-status "planned"]]
+   [:li "Calibrating Items Before IRT and Adaptive Selection" [:span.series-status "planned"]]
+   [:li "When Contexts and Senses Become Identifiable" [:span.series-status "planned"]]]])
 
 ;; A probability model is a disciplined way to reason when one answer is
 ;; unknown. It does not remove uncertainty. It records candidate answers,
@@ -94,16 +113,6 @@
   [:li [:strong "Sample and decide"] [:br] "How can a distribution guide an action?"]
   [:li [:strong "Scale up"] [:br] "How does the same update work with two unknown parameters?"]
   [:li [:strong "Reproduce"] [:br] "How do code, seeds, tests, and rendering make the lesson checkable?"]])
-
-^:kindly/hide-code
-(kind/hiccup
- [:nav.series-toc {:aria-labelledby "series-contents-heading"}
-  [:h2#series-contents-heading "Bayes-to-Lexibench series"]
-  [:p "This article supplies the probability tools used by the later vocabulary-estimation articles."]
-  [:ol
-   [:li [:a {:href "bayes_theorem_simulations.html"} "Bayes' theorem from uncertainty to decision"] [:span.series-status "you are here"]]
-   [:li [:a {:href "beta_binomial_first_pass.html"} "Estimating vocabulary size with a simple Bayesian model"] [:span.series-status "next"]]
-   [:li [:a {:href "pair_frequency_logistic_v2_article.html"} "Does pair frequency predict learner responses?"] [:span.series-status "then"]]]])
 
 ^:kindly/hide-code
 (math/global-controls)

--- a/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
+++ b/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj
@@ -1,8 +1,9 @@
 ^{:kindly/hide-code true
   :kindly/options {:html/deps [:scittle :reagent]}
-  :clay {:title "Bayes' Theorem, Revisited: Three Interactive Simulations"
+  :clay {:hide-info-line true
+         :title "Bayes' Theorem from Uncertainty to Decision"
          :quarto {:author :jamiep
-                  :description "Rebuilding three earlier Bayesian simulations with Kindly, Scittle, Reagent, and accessible SVG."
+                  :description "A visual, interactive introduction to Bayesian updating, posterior sampling, decisions, and Gaussian grid approximation."
                   :type :post
                   :date "2026-07-13"
                   :category :concepts
@@ -17,148 +18,194 @@
 (kind/hiccup
  [:style
   (str
+   ":root{--bp-accent:#1464b5;--bp-accent-soft:#e5f1fb;--bp-warm:#a34f00;--bp-warm-soft:#fff0df;--bp-muted:#4f5b66}"
+   ".quarto-dark{--bp-accent:#73b7ff;--bp-accent-soft:#173653;--bp-warm:#ffc27a;--bp-warm-soft:#4a2d12;--bp-muted:#b9c7d2}"
    "#title-block-header{padding-top:.75rem}"
    "#title-block-header h1{line-height:1.15;overflow-wrap:anywhere}"
    "mjx-container[display=true]{max-width:100%;overflow-x:auto;overflow-y:hidden}"
-   ".bp-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.25rem}"
+   ".bp-callout{border:1px solid color-mix(in srgb,var(--bp-accent) 45%,var(--bs-border-color,#dee2e6));border-left:4px solid var(--bp-accent);background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--bp-accent) 10%);color:var(--bs-body-color,#212529);padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.35rem}"
    ".bp-callout strong{display:block;margin-bottom:.3rem}"
    ".bp-simulator{margin:1.5rem 0}"
-   ".bp-shell{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}"
-   ".bp-shell h3{margin-top:0}"
-   ".bp-shell h4{font-size:1rem}"
-   ".bp-details{border:1px solid #dee2e6;border-radius:.45rem;margin:.85rem 0;background:var(--bs-body-bg,#fff)}"
-   ".bp-details summary{cursor:pointer;font-weight:700;padding:.75rem 1rem}"
-   ".bp-details>div{padding:0 1rem 1rem}"
+   ".bp-shell{border:1px solid var(--bs-border-color,#ced4da);border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+   ".bp-shell h3{margin-top:0}.bp-shell h4{font-size:1rem}"
+   ".bp-details,.bp-predict{border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;margin:.85rem 0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+   ".bp-details summary,.bp-predict summary{cursor:pointer;font-weight:700;padding:.75rem 1rem}"
+   ".bp-details>div,.bp-predict>div{padding:0 1rem 1rem}"
+   ".bp-predict{border-left:4px solid var(--bp-warm);background:color-mix(in srgb,var(--bs-body-bg,#fff) 91%,var(--bp-warm) 9%)}"
    ".bp-controls{display:flex;align-items:end;gap:.65rem;flex-wrap:wrap;margin:1rem 0}"
    ".bp-controls label,.bp-field label{font-weight:700;font-size:.88rem}"
-   ".bp-controls input[type=range]{width:min(15rem,100%);accent-color:#2780e3}"
-   ".bp-button{border:1px solid #6c757d;border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+   ".bp-controls input[type=range]{width:min(15rem,100%);accent-color:var(--bp-accent)}"
+   ".bp-button{border:1px solid var(--bs-border-color,#6c757d);border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
    ".bp-button.bp-primary,.bp-button[aria-pressed=true]{border-color:#1464b5;background:#1464b5;color:#fff}"
+   ".quarto-dark .bp-button.bp-primary,.quarto-dark .bp-button[aria-pressed=true]{border-color:#73b7ff;background:#73b7ff;color:#10212b}"
    ".bp-button:disabled{opacity:.45;cursor:not-allowed}"
-   ".bp-button:focus-visible,.bp-select:focus-visible,.bp-controls input:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 45%,transparent);outline-offset:2px}"
-   ".bp-select{border:1px solid #6c757d;border-radius:.35rem;padding:.5rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+   ".bp-button:focus-visible,.bp-select:focus-visible,.bp-controls input:focus-visible,.bp-details summary:focus-visible,.bp-predict summary:focus-visible{outline:3px solid color-mix(in srgb,var(--bp-accent) 50%,transparent);outline-offset:2px}"
+   ".bp-select{border:1px solid var(--bs-border-color,#6c757d);border-radius:.35rem;padding:.5rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
    ".bp-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,20rem),1fr));gap:1rem;margin:1rem 0}"
-   ".bp-chart{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:.7rem;margin:0;background:var(--bs-body-bg,#fff)}"
+   ".bp-chart{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.5rem;padding:.7rem;margin:0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
    ".bp-chart h4{margin:.1rem 0 .2rem;font-size:.95rem;line-height:1.25}"
    ".bp-chart svg{display:block;width:100%;height:auto}"
-   ".bp-caption,.bp-note{font-size:.86rem;color:#4f5b66;margin:.4rem 0 0}"
+   ".bp-caption,.bp-note{font-size:.86rem;color:var(--bp-muted);margin:.4rem 0 0}"
    ".bp-stat{font-variant-numeric:tabular-nums;margin:.4rem 0}"
-   ".bp-sample-sequence{font-family:var(--bs-font-monospace,monospace);font-size:.82rem;overflow-wrap:anywhere;max-height:6rem;overflow:auto;padding:.55rem;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.35rem;background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 92%,#2780e3 8%);color:var(--bs-body-color,#212529)}"
-   ".bp-axis{stroke:currentColor;stroke-opacity:.5}"
-   ".bp-guide{stroke:currentColor;stroke-opacity:.11}"
-   ".bp-line{fill:none;stroke:#2780e3;stroke-width:3;vector-effect:non-scaling-stroke}"
-   ".bp-line-secondary{fill:none;stroke:#e69f00;stroke-width:2;stroke-dasharray:6 4;vector-effect:non-scaling-stroke}"
-   ".bp-bar-water{fill:#2780e3}"
-   ".bp-bar-land{fill:#c99052}"
-   ".bp-points{fill:none;stroke:#2780e3;stroke-width:2;stroke-linecap:round;vector-effect:non-scaling-stroke}"
-   ".bp-progress{width:100%;height:.55rem;accent-color:#2780e3}"
+   ".bp-sample-sequence{font-family:var(--bs-font-monospace,monospace);font-size:.82rem;overflow-wrap:anywhere;max-height:6rem;overflow:auto;padding:.55rem;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.35rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 92%,var(--bp-accent) 8%);color:var(--bs-body-color,#212529)}"
+   ".bp-axis{stroke:currentColor;stroke-opacity:.5}.bp-guide{stroke:currentColor;stroke-opacity:.11}"
+   ".bp-line{fill:none;stroke:var(--bp-accent);stroke-width:3;vector-effect:non-scaling-stroke}"
+   ".bp-line-secondary{fill:none;stroke:var(--bp-warm);stroke-width:2;stroke-dasharray:6 4;vector-effect:non-scaling-stroke}"
+   ".bp-bar-water{fill:var(--bp-accent)}.bp-bar-land{fill:var(--bp-warm)}"
+   ".bp-points{fill:none;stroke:var(--bp-accent);stroke-width:2;stroke-linecap:round;vector-effect:non-scaling-stroke}"
+   ".bp-progress{width:100%;height:.55rem;accent-color:var(--bp-accent)}"
    ".bp-formula{font-family:var(--bs-font-monospace,monospace);overflow-wrap:anywhere}"
    ".bp-heat-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,17rem),1fr));gap:1rem}"
-   ".bp-empty{display:grid;place-items:center;min-height:11rem;border:1px dashed #adb5bd;border-radius:.35rem;color:#4f5b66;text-align:center;padding:1rem}"
+   ".bp-empty{display:grid;place-items:center;min-height:11rem;border:1px dashed var(--bs-border-color,#adb5bd);border-radius:.35rem;color:var(--bp-muted);text-align:center;padding:1rem}"
    ".bp-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}"
-   ".quarto-dark .bp-caption,.quarto-dark .bp-note,.quarto-dark .bp-empty{color:#b9c7d2}"
-   "@media(max-width:575px){.bp-shell{padding:.75rem}.bp-controls{align-items:stretch}.bp-button{flex:1}.bp-chart{padding:.5rem}}")])
+   ".bp-process-strip{display:grid;grid-template-columns:repeat(7,minmax(0,auto));align-items:stretch;gap:.4rem;margin:1rem 0}"
+   ".bp-process-step{display:grid;align-content:center;min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.65rem;background:var(--bs-body-bg,#fff);text-align:center;overflow-wrap:anywhere}"
+   ".bp-process-step strong{display:block}.bp-process-step small{color:var(--bp-muted)}"
+   ".bp-process-symbol{display:grid;place-items:center;font-size:1.3rem;font-weight:800;color:var(--bp-accent)}"
+   ".bp-reading-guide{border-left:4px solid var(--bp-accent);padding:.2rem 0 .2rem 1rem;margin:1rem 0}"
+   ".bp-reading-guide h3{font-size:1rem;margin:.1rem 0 .4rem}.bp-reading-guide ul{margin-bottom:.2rem}"
+   ".bp-definition-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:.7rem;margin:1rem 0}"
+   ".bp-definition{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.75rem;background:var(--bs-body-bg,#fff)}"
+   ".bp-definition dt{font-weight:800;color:var(--bp-accent)}.bp-definition dd{margin:.25rem 0 0}"
+   ".bp-engineering-caption{text-align:center;color:var(--bp-muted);font-size:.88rem}"
+   ".series-toc{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}"
+   ".series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}"
+   ".series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--bp-muted)}"
+   "@media(max-width:767px){.bp-process-strip{grid-template-columns:minmax(0,1fr)}.bp-process-symbol{min-height:1.2rem}.bp-shell{padding:.75rem}.bp-controls{align-items:stretch}.bp-button{flex:1}.bp-chart{padding:.5rem}}")])
 
 ^:kindly/hide-code
 (math/styles)
 
+;; A probability model is a disciplined way to reason when one answer is
+;; unknown. It does not remove uncertainty. It records candidate answers,
+;; states how observations would arise under each candidate, and updates their
+;; relative plausibility when data arrive.
+;;
+;; This tutorial rebuilds three simulations I first made with Daniel Slutsky's
+;; [JointProb group](https://scicloj.github.io/docs/community/groups/jointprob/).
+;; The examples come from sections 2.2, 3.2, and 4.3 of Richard McElreath's
+;; *Statistical Rethinking*. No statistics or programming background is
+;; assumed. Each chapter asks one practical question:
+
 ^:kindly/hide-code
 (kind/hiccup
- [:style
-  ".series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#4f5b66}.quarto-dark .series-status{color:#b9c7d2}.bp-change-details>summary{font-size:1.3rem;line-height:1.2}.bp-change-details ul{margin-bottom:0}"])
-
-;; I thought I'd reproduce my previous learning about [Bayes' theorem
-;; simulations](https://jointprob.github.io/jointprob-shadow-cljs/#normal-distribution)
-;; ([source code](https://github.com/jointprob/jointprob-shadow-cljs/tree/master/src/cljs))
-;; as a Civitas article. I previously produced these simulations when I was
-;; working with [Daniel's JointProb
-;; group](https://scicloj.github.io/docs/community/groups/jointprob/) and used
-;; visualisation tools that were easily available at the time. I'm pretty
-;; confident that the current visualisation tools are going to do a lot better
-;; job with this simulation, judging by how wonderful a job they did with [my
-;; first Civitas article](beta_binomial_first_pass.html).
+ [:ol.article-chapter-map
+  [:li [:strong "Update"] [:br] "How should observations change uncertainty?"]
+  [:li [:strong "Sample and decide"] [:br] "How can a distribution guide an action?"]
+  [:li [:strong "Scale up"] [:br] "How does the same update work with two unknown parameters?"]
+  [:li [:strong "Reproduce"] [:br] "How do code, seeds, tests, and rendering make the lesson checkable?"]])
 
 ^:kindly/hide-code
 (kind/hiccup
  [:nav.series-toc {:aria-labelledby "series-contents-heading"}
-  [:h2#series-contents-heading "Series contents"]
-  [:p
-   [:strong "Revisiting basic Bayes' theorem and applying it to a real word problem: estimating vocabulary size from "]
-   [:a {:href "https://lexibench.com/"} "Lexibench.com"]
-   [:strong " quiz responses."]]
+  [:h2#series-contents-heading "Bayes-to-Lexibench series"]
+  [:p "This article supplies the probability tools used by the later vocabulary-estimation articles."]
   [:ol
-   [:li [:a {:href "bayes_theorem_simulations.html"}
-         "Bayes' Theorem, Revisited: Three Interactive Simulations"]
-    [:span.series-status "published"]]
-   [:li [:a {:href "beta_binomial_first_pass.html"}
-         "Estimating Vocabulary Size with a Simple Bayesian Model"]
-    [:span.series-status "published"]]
-   [:li "Does Pair Frequency Predict Learner Responses?"
-    [:span.series-status "planned"]]
-   [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
-    [:span.series-status "planned"]]
-   [:li "From Correlated Form Pairs to Latent Lemma Knowledge"
-    [:span.series-status "planned"]]
-   [:li "Modelling Correct, Wrong, and Don't-Know Separately"
-    [:span.series-status "planned"]]
-   [:li "Calibrating Items Before IRT and Adaptive Selection"
-    [:span.series-status "planned"]]
-   [:li "When Contexts and Senses Become Identifiable"
-    [:span.series-status "planned"]]]])
+   [:li [:a {:href "bayes_theorem_simulations.html"} "Bayes' theorem from uncertainty to decision"] [:span.series-status "you are here"]]
+   [:li [:a {:href "beta_binomial_first_pass.html"} "Estimating vocabulary size with a simple Bayesian model"] [:span.series-status "next"]]
+   [:li [:a {:href "pair_frequency_logistic_v2_article.html"} "Does pair frequency predict learner responses?"] [:span.series-status "then"]]]])
 
 ^:kindly/hide-code
 (math/global-controls)
 
-^:kindly/hide-code
-(kind/hiccup
- [:details.bp-details.bp-change-details
-  [:summary "What I changed in this recreation"]
-  [:div
-   [:p "I kept the old application's complete three-part teaching sequence and its numerical grids, but rebuilt how it is delivered:"]
-   [:ul
-    [:li "The three routed Shadow-CLJS pages are now one executable Civitas article, so the globe update, posterior-sampling decision, and Gaussian update can be read as one argument."]
-    [:li "The compiled Shadow-CLJS application is replaced by the same Kindly–Scittle–Reagent arrangement used in my first article. The mathematical core lives in this " [:code ".clj"] " article; browser state and controls live in one adjacent " [:code ".cljs"] " file."]
-    [:li "Vega, Hanami, Semantic UI React, and MathJax React are removed. Kindly and Quarto render the prose and equations; semantic HTML supplies the controls; Reagent renders the visualisations directly as responsive SVG."]
-    [:li "The original 201-point probability grid, four selectable priors, 200-item globe simulation, 2,000 animated posterior draws, 10,000-draw comparison, 41 × 41 Gaussian parameter grid, and complete adult-height dataset are preserved."]
-    [:li "Previously ambient calls to " [:code "rand"] " are replaced by explicit seeds. Reset now replays the same globe data and posterior draws, making screenshots, explanations, and later regression checks reproducible."]
-    [:li "The old long quotations from " [:em "Statistical Rethinking"] " are paraphrased while retaining their examples, section references, and attribution."]
-    [:li "Every chart now has an SVG title and description; controls have associated labels and explicit keyboard behavior; status text is announced selectively; and the layout collapses without horizontal overflow on small screens."]
-    [:li "The Gaussian heat maps use within-panel logarithmic opacity. This keeps low but non-zero plausibilities visible as the posterior concentrates. Their colour is therefore for comparing location and shape within a panel, not absolute density across panels."]
-    [:li "I added direct " [:strong "Previous"] " and " [:strong "Next"] " controls to the height simulation and bounded its final update, avoiding the old end-of-data indexing edge case."]]
-   [:p "The original project was a three-page Shadow-CLJS application using Vega, Hanami, Semantic UI React, and MathJax React. This version keeps the three lessons together in one executable Civitas article. Kindly renders the article, while Scittle and Reagent run the controls directly in the browser. The charts are responsive SVG with text alternatives, so there is no JavaScript build step and no charting wrapper between the data and the marks."]
-   [:p "All simulated randomness below is seeded. Resetting a simulation replays the same sequence, which makes the explanations and any later checks repeatable."]]])
+;; ## The five ideas under every update
+;;
+;; Suppose I do not know what proportion of a globe is covered by water.
+;; **Uncertainty** means more than one answer remains credible. A **probability**
+;; is a number from 0 to 1 used here to describe how strongly the model supports
+;; an event or candidate. The unknown water proportion, called $p$, is a
+;; **parameter**: a quantity the model tries to learn. A **model** is the set of
+;; assumptions connecting that parameter to possible observations. The
+;; observed water and land outcomes are the **data**.
 
 ^:kindly/hide-code
 (kind/hiccup
- [:div.bp-callout
-  [:strong "What is being recreated"]
-  "The globe-toss grid approximation, sampling from its posterior to make a decision under absolute loss, and sequential Gaussian updating for adult heights. The long quotations in the old application are paraphrased here and still attributed to their source."])
+ [:dl.bp-definition-grid
+  [:div.bp-definition [:dt "Uncertainty"] [:dd "Several answers are still possible."]]
+  [:div.bp-definition [:dt "Probability"] [:dd "A 0-to-1 numerical description of uncertainty inside a stated model."]]
+  [:div.bp-definition [:dt "Parameter"] [:dd "An unknown quantity in the model, such as the water proportion p."]]
+  [:div.bp-definition [:dt "Model"] [:dd "Assumptions saying how data could be generated for each parameter value."]]
+  [:div.bp-definition [:dt "Data"] [:dd "Recorded observations used to compare the candidates."]]])
 
-;; ## 1. Updating a probability with globe tosses
-;;
-;; The first example follows the globe thought experiment in section 2.2 of
-;; Richard McElreath's *Statistical Rethinking*. Toss a small globe, catch it,
-;; and note whether the point beneath your index finger is water or land. The
-;; unknown parameter $p$ is the proportion of the globe covered by water.
-;;
-;; I approximate the continuous range of $p$ using 201 candidates:
+;; I cannot calculate with every decimal between 0 and 1 directly in this
+;; simple demonstration, so I use **grid approximation**: replace the continuous
+;; range by 201 equally spaced candidate values.
 ;;
 ;; $$p \in \{0, 0.005, 0.010, \ldots, 0.995, 1\}.$$
+;;
+;; Read this as: “$p$ is one of 201 candidates from zero to one, spaced by
+;; 0.005.” A finer grid would approximate the continuous range more closely but
+;; would require more calculation.
 
 ^:kindly/hide-code
 (math/explanation
  "math-grid-candidates"
  "The discrete grid of candidate water proportions"
  [["p" "A candidate value for the unknown proportion of the globe covered by water; it must lie between 0 and 1."]
-  ["∈" "“Is an element of” or “is one of the values in.”"]
+  ["∈" "‘Is an element of’ or ‘is one of the values in.’"]
   ["{…}" "Braces list the allowed candidate values rather than one continuous interval."]
-  ["0.005" "The distance between adjacent candidates. Including both 0 and 1 gives 201 grid points."]
-  ["…" "The same 0.005 step continues through the omitted values."]]
- "This grid is a numerical approximation: the underlying water proportion is treated conceptually as continuous.")
+  ["0.005" "The distance between adjacent candidates. Including both endpoints gives 201 grid points."]]
+ "The grid is a numerical approximation; the underlying proportion is still conceived as continuous.")
 
+^:kindly/hide-code
 (def probability-grid
   (mapv #(/ % 200.0) (range 201)))
 
+^:kindly/hide-code
+(math/code-detail
+ "code-probability-grid"
+ "Constructing the 201-point probability grid"
+ [:div
+  [:p "Clojure's " [:code "range"] " produces the integers 0 through 200. Dividing each by 200 gives 0, 0.005, …, 1. The result is stored as a vector so its order is stable."]
+  [:pre [:code "(def probability-grid\n  (mapv #(/ % 200.0) (range 201)))"]]
+  [:p "Check: " [:code "(count probability-grid)"] " must equal 201, and the assertion at the end of this article enforces it."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj"} "View the complete executable Clojure article"]]])
+
+;; Before data, each candidate receives a **prior** weight. After data, the
+;; **likelihood** says how compatible those data are with each candidate. Their
+;; product is an **unnormalised weight**: useful for ranking, but not yet a set
+;; of probabilities that sums to 1. **Normalisation** divides every product by
+;; their total. The resulting **posterior** is the updated distribution over
+;; candidates.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-process-strip {:role "img" :aria-label "Prior multiplied by likelihood produces unnormalised weights, which are normalised to produce the posterior"}
+  [:div.bp-process-step [:strong "Prior"] [:small "before these data"]]
+  [:div.bp-process-symbol {:aria-hidden "true"} "×"]
+  [:div.bp-process-step [:strong "Likelihood"] [:small "what the data favour"]]
+  [:div.bp-process-symbol {:aria-hidden "true"} "="]
+  [:div.bp-process-step [:strong "Raw weights"] [:small "relative support"]]
+  [:div.bp-process-symbol {:aria-hidden "true"} "→"]
+  [:div.bp-process-step [:strong "Posterior"] [:small "normalised update"]]])
+
+;; ## 1. Update: learning from globe tosses
+;;
+;; Imagine tossing and catching a globe. The point under a finger is recorded
+;; as water or land. If a candidate says water is common, water observations
+;; should be less surprising under it. This is the likelihood's job.
+;;
+;; For $W$ water observations and $L$ land observations, one particular ordered
+;; sequence has probability
+;;
+;; $$p^W(1-p)^L.$$
+;;
+;; In plain English: multiply $p$ once for every water result and $1-p$ once
+;; for every land result. This assumes the observations are independent once
+;; $p$ is fixed.
+
+^:kindly/hide-code
+(math/explanation
+ "math-ordered-sequence"
+ "Probability of one particular water–land sequence"
+ [["p" "The probability that one independent toss lands on water."]
+  ["1 − p" "The complementary probability that one toss lands on land."]
+  ["W" "The number of water observations in the sequence."]
+  ["L" "The number of land observations in the sequence."]
+  ["p^W(1 − p)^L" "The product of all water and land probability contributions."]]
+ "This expression describes one specified ordering, such as W–L–W.")
+
+^:kindly/hide-code
 (defn binomial-coefficient
   "Number of orderings containing k successes among n observations."
   [n k]
@@ -169,6 +216,33 @@
             1.0
             (range 1 (inc k)))))
 
+;; When only the counts matter, there are
+;;
+;; $$\binom{W+L}{W}=\frac{(W+L)!}{W!L!}$$
+;;
+;; possible orderings. Read this as: choose which $W$ of the $W+L$ positions
+;; contain water. The exclamation mark means factorial—for example,
+;; $3!=3\times2\times1$. Multiplying the ordering count by the probability of
+;; one ordering gives the **binomial likelihood**:
+;;
+;; $$\Pr(W,L\mid p)=\binom{W+L}{W}p^W(1-p)^L.$$
+;;
+;; Read this as: “if candidate $p$ were fixed, what probability would this
+;; model assign to seeing these water and land counts?” Once the data are fixed
+;; and candidates vary, the same expression is called a likelihood.
+
+^:kindly/hide-code
+(math/explanation
+ "math-binomial-likelihood"
+ "The binomial likelihood"
+ [["Pr(W,L | p)" "The probability of the observed counts, conditional on candidate p."]
+  ["|" "‘Given’ or ‘conditional on.’"]
+  ["(W + L choose W)" "The number of distinct sequences with the same counts."]
+  ["n!" "n factorial: multiply the positive integers from n down to 1."]
+  ["p^W(1 − p)^L" "The probability of one particular ordering."]]
+ "The ordering count is constant across p for fixed data, so it changes scale but not the likelihood curve's shape.")
+
+^:kindly/hide-code
 (defn normalize-mean-one
   "Scale non-negative grid weights so their arithmetic mean is one."
   [weights]
@@ -177,6 +251,7 @@
       (mapv #(/ % mean-weight) weights)
       (vec weights))))
 
+^:kindly/hide-code
 (defn binomial-likelihood
   "Likelihood of water and land counts for one candidate p."
   [p water land]
@@ -184,6 +259,7 @@
      (Math/pow p water)
      (Math/pow (- 1.0 p) land)))
 
+^:kindly/hide-code
 (defn grid-posterior
   "Posterior grid weights for a prior and water/land observations."
   [prior water land]
@@ -192,87 +268,80 @@
        (mapv * prior)
        normalize-mean-one))
 
+^:kindly/hide-code
 (def uniform-prior (vec (repeat 201 1.0)))
 
+^:kindly/hide-code
 (def example-posterior
   (grid-posterior uniform-prior 6 3))
 
-{:grid-points (count probability-grid)
- :example :six-water-three-land
- :posterior-mode (first (apply max-key second
-                               (map vector probability-grid example-posterior)))}
-
-;; For $W$ water observations and $L$ land observations, the probability of one
-;; particular ordered sequence is
-;;
-;; $$p^W(1-p)^L.$$
+^:kindly/hide-code
+(def example-posterior-mode
+  (first (apply max-key second
+                (map vector probability-grid example-posterior))))
 
 ^:kindly/hide-code
-(math/explanation
- "math-ordered-sequence"
- "Probability of one particular water–land sequence"
- [["p" "The probability that one independent toss lands on water."]
-  ["1 − p" "The complementary probability that one toss lands on land."]
-  ["W" "The number of water observations in the sequence."]
-  ["L" "The number of land observations in the sequence."]
-  ["p^W" "The probability contribution from the W water observations."]
-  ["(1 − p)^L" "The probability contribution from the L land observations."]
-  ["multiplication" "Independent observations let their probabilities be multiplied."]]
- "This is for one specified ordering, such as W–L–W, not yet for every ordering with the same counts.")
-;;
-;; There are
-;;
-;; $$\binom{W+L}{W}=\frac{(W+L)!}{W!L!}$$
+(kind/hiccup
+ [:p.bp-note
+  [:span.article-marker "Check"]
+  (str "The executable six-water, three-land example uses "
+       (count probability-grid) " candidates and peaks at p = "
+       example-posterior-mode ".")])
 
-^:kindly/hide-code
-(math/explanation
- "math-binomial-coefficient"
- "Number of orderings with the same water and land counts"
- [["W + L" "The total number of observations."]
-  ["(W + L choose W)" "Choose which W of the W + L positions contain water; land fills the remaining positions."]
-  ["n!" "“n factorial”: multiply every positive integer from n down to 1."]
-  ["(W + L)! / (W!L!)" "The factorial formula for the same count; dividing removes rearrangements among identical water and identical land observations."]]
- "This binomial coefficient is a count, not a probability. For W = 2 and L = 1, it counts WWL, WLW, and LWW: three orderings.")
+;; Bayes' theorem names this update:
 ;;
-;; orderings with the same counts, giving the binomial likelihood
+;; $$\Pr(p\mid W,L)=\frac{\Pr(W,L\mid p)\Pr(p)}{\Pr(W,L)}.$$
 ;;
-;; $$\Pr(W,L\mid p)=\binom{W+L}{W}p^W(1-p)^L.$$
-
-^:kindly/hide-code
-(math/explanation
- "math-binomial-likelihood"
- "The binomial likelihood"
- [["Pr(W,L | p)" "The probability of observing W water and L land outcomes, conditional on a proposed water proportion p."]
-  ["|" "“Given” or “conditional on.” Here p is treated as fixed while the possible data vary."]
-  ["(W + L choose W)" "The number of distinct sequences having these same counts."]
-  ["p^W(1 − p)^L" "The probability of any one such sequence."]
-  ["likelihood" "The same expression viewed as a function of p after the observed W and L have been fixed."]]
- "The ordering count multiplies the probability of one ordering to obtain the probability of all orderings with these counts.")
-;;
-;; Bayes' theorem combines that likelihood with the prior:
-;;
-;; $$\Pr(p\mid W,L)=\frac{\Pr(W,L\mid p)\Pr(p)}{\Pr(W,L)},$$
+;; Read it from right to left: multiply the prior support for candidate $p$ by
+;; the likelihood of the observations under that candidate, then divide by the
+;; overall probability of the observations so all posterior probabilities sum
+;; to 1. On this finite grid, normalising all products performs that division.
 
 ^:kindly/hide-code
 (math/explanation
  "math-bayes-theorem"
  "Bayes’ theorem for the water proportion"
- [["Pr(p | W,L)" "The posterior: the updated plausibility of p after observing W water and L land outcomes."]
-  ["Pr(W,L | p)" "The likelihood: how compatible the observed counts are with candidate p."]
-  ["Pr(p)" "The prior plausibility assigned to p before these observations."]
-  ["Pr(W,L)" "The evidence or marginal probability of the observations, averaged across the prior; it normalises the posterior."]
-  ["likelihood × prior" "The unnormalised posterior weight for candidate p."]
-  ["|" "“Given.” Reversing the quantities around the bar changes the conditional probability."]]
- "On the finite grid, divide every likelihood-times-prior weight by their total. That numerical normalisation plays the denominator’s role.")
-;;
-;; where the denominator is the average probability of the data across the
-;; prior. On a grid, normalising the products performs the same job.
-;;
-;; The simulator restores all four priors from the old application: uniform,
-;; step up, step down, and a symmetric ramp. Add water or land deliberately, or
-;; let a seeded process whose true water probability is 0.6 generate up to 200
-;; observations. The panels separate the previous posterior, the latest
-;; observation's likelihood, the full likelihood, and the new posterior.
+ [["Pr(p | W,L)" "The posterior support for p after observing W water and L land outcomes."]
+  ["Pr(W,L | p)" "The likelihood of those observations under candidate p."]
+  ["Pr(p)" "The prior support for p before these observations."]
+  ["Pr(W,L)" "The overall or marginal probability of the data; it normalises the products."]
+  ["likelihood × prior" "The unnormalised posterior weight for candidate p."]]
+ "On a finite grid, divide each likelihood-times-prior product by the sum of all products.")
+
+^:kindly/hide-code
+(math/code-detail
+ "code-normalise-posterior"
+ "Normalising likelihood-times-prior weights"
+ [:div
+  [:p "The pipeline evaluates the likelihood at every candidate, multiplies candidate by candidate with the prior, then applies one common scale factor. Scaling to mean 1 rather than sum 1 preserves the same posterior shape used by the charts."]
+  [:pre [:code "(defn grid-posterior [prior water land]\n  (->> probability-grid\n       (mapv #(binomial-likelihood % water land))\n       (mapv * prior)\n       normalize-mean-one))"]]
+  [:p "Check: the article asserts that the 201 weights' arithmetic mean is 1 to floating-point tolerance."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations.clj"} "View the complete posterior implementation"]]])
+
+;; A sequential update needs no new rule. After one observation, the posterior
+;; contains everything this model carries forward about $p$. It therefore
+;; becomes the next observation's prior: yesterday's posterior is today's
+;; prior. The dynamic strip inside the simulator shows the current prior,
+;; latest-observation likelihood, raw product, and normalised posterior.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:details.bp-predict
+  [:summary "Predict before revealing: what should one water observation do?"]
+  [:div
+   [:p "First make a prediction. Should candidates near p = 0, p = 0.5, or p = 1 gain the most relative support?"]
+   [:p [:strong "Reveal:"] " one water observation has likelihood p, so it favours larger p values. A land observation has likelihood 1 − p and favours smaller values."]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-reading-guide
+  [:h3 "How to read the globe simulator"]
+  [:ul
+   [:li "Horizontal position is candidate water proportion p, from 0 to 1."]
+   [:li "Curve height is relative support or likelihood; it is not the probability of one exact p."]
+   [:li "Use Water or Land for deliberate evidence. Random sample uses hidden true p = 0.6."]
+   [:li "Change the prior to see its influence early; add data to see the likelihood increasingly dominate."]]
+  [:p.bp-caption "The two full-likelihood charts differ by a constant multiplier, so their normalised shapes match."]])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -281,38 +350,53 @@
    [:p "Loading the globe-toss Bayesian update simulator…"]]
   [:noscript "This simulator needs JavaScript. The equations and executable Clojure above remain available without it."]])
 
-;; The ordered-sequence likelihood and the likelihood of any ordering have the
-;; same shape as functions of $p$: the binomial coefficient is constant for
-;; fixed $W$ and $L$. Their raw vertical scales differ, but normalising either
-;; curve produces the same visual shape. Keeping both panels makes that fact
-;; visible rather than leaving it buried in the algebra.
+^:kindly/hide-code
+(math/code-detail
+ "code-seeded-reset"
+ "Seeded random globe observations and reset"
+ [:div
+  [:p "A random seed is a starting number for a repeatable pseudo-random sequence. Reset creates the generator from the same seed again, so it replays the same simulated observations. That is deterministic replay: identical versioned inputs and seed produce identical results."]
+  [:pre [:code "(def update-seed 20260713)\n\n(defn generated-observation! []\n  (if (< (uniform! @update-rng) 0.6) :water :land))\n\n(defn reset-update! []\n  (cancel-update-timer!)\n  (reset! update-rng (make-rng update-seed))\n  (let [prior (:prior @update-state)\n        speed (:speed @update-state)]\n    (reset! update-state\n            (assoc initial-update-state :prior prior :speed speed))))"]]
+  [:p "The browser keeps the sequence already drawn in browser state—data held in memory for the current page. Clearing replaces that state and rewinds the generator."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs"} "View the complete browser implementation"]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:strong "Chapter 1 recap"]
+  [:p "Build: list candidate values and specify a prior and likelihood. Check: normalise and inspect the update after known observations. Decide: carry the posterior forward as the prior for the next observation."]])
+
+;; ## 2. Sample: turning uncertainty into a decision
 ;;
-;; ## 2. Sampling from the posterior and choosing a decision
+;; A posterior is a distribution, not automatically a single estimate. To act,
+;; we must say what action is available and what mistakes cost. A **decision**
+;; is the chosen action. A **loss function** assigns a cost to each possible
+;; decision–truth pair. Change the loss and the best estimate can change even
+;; when the posterior does not.
 ;;
-;; Section 3.2 of *Statistical Rethinking* turns the globe problem into a bet.
-;; Choose a value $d$ for the proportion of water. A perfect answer earns $100$,
-;; but the payoff falls in proportion to the absolute error $|d-p|$. As in the
-;; previous application, I make that concrete as a loss of $1 for every 0.01 of
-;; error.
-;;
-;; The browser first generates a reproducible dataset of 100 globe observations
-;; with true $p=0.6$, then calculates its grid posterior. For every candidate
-;; decision $d$, the expected absolute loss is
+;; Here the decision $d$ is a claimed water proportion. A perfect answer earns
+;; $100; every 0.01 of absolute error loses $1. The **expected absolute loss**
+;; is
 ;;
 ;; $$E[|d-p|\mid W,L] = \sum_p |d-p|\Pr(p\mid W,L).$$
+;;
+;; Read this as: for each possible $p$, calculate how far decision $d$ misses,
+;; weight that error by the posterior support for $p$, and add. Choose the $d$
+;; with the smallest weighted average error.
 
 ^:kindly/hide-code
 (math/explanation
  "math-expected-absolute-loss"
  "Posterior expected absolute loss"
- [["d" "A candidate decision: the water proportion you choose for the bet."]
+ [["d" "A candidate decision: the water proportion chosen for the bet."]
   ["p" "One possible true water proportion on the grid."]
-  ["|d − p|" "Absolute error: the non-negative distance between the decision and that possible truth."]
-  ["E[… | W,L]" "Expected value after conditioning on the observed water and land counts."]
-  ["Σ_p" "Sum over every candidate p on the probability grid."]
+  ["|d − p|" "Absolute error: the non-negative distance between decision and possible truth."]
+  ["E[… | W,L]" "Expected value after conditioning on the observed counts."]
+  ["Σ_p" "Add one weighted error for every candidate p."]
   ["Pr(p | W,L)" "The posterior probability weight assigned to candidate p."]]
- "Each possible error is weighted by its posterior plausibility. The decision d with the smallest resulting average is preferred under absolute loss.")
+ "The decision with the smallest posterior-weighted average absolute error is preferred.")
 
+^:kindly/hide-code
 (defn expected-absolute-loss
   "Expected absolute error at decision d for grid weights."
   [posterior d]
@@ -323,27 +407,51 @@
                       posterior))
        weight-total)))
 
+^:kindly/hide-code
 (def example-losses
   (mapv #(expected-absolute-loss example-posterior %)
         probability-grid))
 
+^:kindly/hide-code
 (def example-minimum-loss
   (apply min-key second (map vector probability-grid example-losses)))
 
-{:example :six-water-three-land
- :minimum-loss-decision (first example-minimum-loss)
- :expected-absolute-loss (second example-minimum-loss)}
+^:kindly/hide-code
+(kind/hiccup
+ [:p.bp-note
+  [:span.article-marker "Check"]
+  (str "For the executable six-water, three-land example, the grid decision "
+       "minimising expected absolute loss is d = "
+       (first example-minimum-loss) ".")])
 
-;; The direct calculation iterates over decisions from 0 to 1 in steps of
-;; 0.005. For each decision it multiplies the loss at every possible $p$ by that
-;; $p$'s posterior weight and averages over the curve. The lowest point of the
-;; resulting loss curve is the decision that minimises expected loss.
+;; Directly evaluating every $d$ works on this small grid. Another route is
+;; **posterior sampling**: draw candidate values with frequency proportional to
+;; their posterior probability. The cloud of draws approximates the
+;; distribution. Under absolute loss, the posterior median minimises expected
+;; loss.
 ;;
-;; We can reach the same answer by drawing possible values of $p$ from the
-;; posterior. Under absolute loss, the posterior median is the optimal
-;; decision. The interactive view animates up to 2,000 draws, then compares
-;; their trace, 200-bin counts, and standardised density with a fixed 10,000-draw
-;; simulation. Every visible summary uses the draws shown by that simulation.
+;; Repeating random draws to approximate a distribution or numerical result is
+;; **Monte Carlo approximation**. More draws reduce simulation noise, but do
+;; not repair a poor model. This interaction animates 2,000 draws and compares
+;; them with a fixed 10,000-draw run.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:details.bp-predict
+  [:summary "Predict before revealing: where should the sample median settle?"]
+  [:div
+   [:p "Inspect the posterior from 100 globe observations. Predict whether its median will settle below, near, or above the hidden true p = 0.6."]
+   [:p [:strong "Then test it:"] " start slowly enough to see individual draws, increase the speed, and compare the live median with the direct loss minimum."]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-reading-guide
+  [:h3 "How to read the sampling simulator"]
+  [:ul
+   [:li "The first row fixes one 100-observation dataset and shows its posterior and loss curve."]
+   [:li "The trace plots draw order vertically by sampled p; the histogram counts draws; the density rescales those counts."]
+   [:li "The animated and fixed panels use different seeded streams but the same posterior."]
+   [:li "Watch the running median wobble, then stabilise as the number of draws increases."]]])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -352,35 +460,57 @@
    [:p "Loading the posterior sampling and decision simulator…"]]
   [:noscript "This simulator needs JavaScript. The expected-loss calculation above remains available without it."]])
 
-;; ## 3. Updating a Gaussian model for adult heights
+^:kindly/hide-code
+(math/code-detail
+ "code-weighted-sampling"
+ "Drawing grid values in proportion to posterior weight"
+ [:div
+  [:p "First normalise the 201 weights so they sum to 1. Draw a uniform number between 0 and 1, then walk through cumulative posterior mass until it reaches that number. Return the corresponding grid value."]
+  [:pre [:code "(defn weighted-grid-sample! [rng]\n  (let [target (uniform! rng)]\n    (loop [index 0\n           cumulative (first fixed-posterior-mass)]\n      (if (or (>= cumulative target)\n              (= index (dec (count probability-grid))))\n        (nth probability-grid index)\n        (recur (inc index)\n               (+ cumulative\n                  (nth fixed-posterior-mass (inc index))))))))"]]
+  [:p "The fixed 10,000 draws are computed once from their own seed. The animated stream is reset independently, so interaction never changes the comparison result."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs"} "View the complete posterior-sampling implementation"]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:strong "Chapter 2 recap"]
+  [:p "Build: define the action and its loss. Check: compare the direct grid minimum with a seeded Monte Carlo approximation. Decide: report the estimate appropriate to the declared loss, not a context-free ‘best’ number."]])
+
+;; ## 3. Scale up: a Gaussian model with two parameters
 ;;
-;; The final simulation follows section 4.3 of *Statistical Rethinking*. A
-;; Gaussian distribution has two parameters: its mean $\mu$ and standard
-;; deviation $\sigma$. There are infinitely many possible pairs, so the
-;; original exercise considers a finite grid and ranks each candidate Gaussian
-;; by how compatible it is with the observed adult heights.
+;; The globe model had one parameter. Adult height introduces two. A
+;; **Gaussian distribution**—the familiar symmetric bell shape—is described by
+;; its **mean** $\mu$, which locates the centre, and **standard deviation**
+;; $\sigma$, which measures typical spread around the centre. Its **density**
+;; describes relative concentration near a height; because height is
+;; continuous, density at one exact point is not itself a probability.
 ;;
-;; For an observed height $h$, a candidate $(\mu,\sigma)$ has density
+;; For observed height $h$, the Gaussian density under candidate
+;; $(\mu,\sigma)$ is
 ;;
 ;; $$f(h\mid\mu,\sigma)=
 ;; \frac{1}{\sigma\sqrt{2\pi}}
 ;; \exp\left(-\frac{(h-\mu)^2}{2\sigma^2}\right).$$
+;;
+;; Read it as: density is highest when $h$ is near candidate mean $\mu$ and
+;; falls as the squared distance grows; candidate spread $\sigma$ controls how
+;; quickly it falls. For a fixed observed height, comparing this density across
+;; parameter pairs gives the likelihood.
 
 ^:kindly/hide-code
 (math/explanation
  "math-gaussian-density"
  "Gaussian density for one observed height"
- [["f(h | μ,σ)" "The probability density at height h for the candidate Gaussian described by μ and σ; a density is not the probability of one exact height."]
+ [["f(h | μ,σ)" "The density at height h for the candidate Gaussian described by μ and σ."]
   ["h" "The observed adult height."]
-  ["μ" "The candidate mean, which locates the centre of the distribution."]
-  ["σ" "The candidate standard deviation, which controls the distribution’s spread and must be positive."]
-  ["π" "Pi, the circle constant, appearing in the Gaussian normalising factor."]
-  ["exp(a)" "The exponential function e raised to the power a."]
-  ["(h − μ)^2" "The squared distance of the observation from the candidate mean."]
-  ["1 / (σ√(2π))" "The normalising factor that makes the total area under the density curve equal 1."]
-  ["−(h − μ)^2 / (2σ^2)" "The exponent makes density fall as h moves farther from μ, relative to spread σ."]]
- "For fixed h, this density is also the observation’s likelihood across candidate μ and σ pairs.")
+  ["μ" "The candidate mean, locating the distribution's centre."]
+  ["σ" "The positive candidate standard deviation, controlling spread."]
+  ["π" "Pi, appearing in the Gaussian normalising factor."]
+  ["exp(a)" "The exponential function e raised to power a."]
+  ["(h − μ)^2" "The squared distance of the observation from the candidate mean."]]
+ "For fixed h, this density is the observation's likelihood across candidate μ and σ pairs.")
 
+^:kindly/hide-code
 (defn normal-density
   "Gaussian probability density at x."
   [x mean sd]
@@ -388,20 +518,43 @@
                   (Math/pow sd 2.0)))
      (* (Math/sqrt (* 2.0 Math/PI)) sd)))
 
-(normal-density 151.765 155.0 8.0)
+^:kindly/hide-code
+(def example-height-density
+  (normal-density 151.765 155.0 8.0))
 
-;; The grid matches the old simulation: 41 values of $\mu$ from 150 to 160 and
-;; 41 values of $\sigma$ from 7 to 9, or 1,681 candidate Gaussians. The prior is
-;; uniform over $\sigma$ and gives $\mu$ a Normal(178, 20) density. For each
-;; height, the display shows three heat maps:
-;;
-;; 1. the posterior before considering the next height;
-;; 2. the relative likelihood supplied by that height;
-;; 3. the posterior after multiplying and normalising.
-;;
-;; Move one height at a time or play through the complete dataset. A logarithmic
-;; colour scale keeps low but non-zero plausibilities visible after the
-;; posterior becomes concentrated.
+;; The preserved grid contains 41 means from 150 to 160 cm crossed with 41
+;; standard deviations from 7 to 9 cm: $41\times41=1{,}681$ candidate models.
+;; Each observed height supplies a likelihood surface. Multiplying that surface
+;; by the preceding posterior and normalising produces the next posterior—the
+;; same sequential rule as before, now across a two-dimensional grid.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-gaussian-update"
+ "Sequentially updating the 41 × 41 Gaussian grid"
+ [:div
+  [:p "The cache starts with one prior surface. For each required height, the browser computes all 1,681 likelihoods, multiplies them pointwise by the last posterior, normalises, and appends both surfaces."]
+  [:pre [:code "(defn ensure-gaussian-step! [target-posterior-count]\n  (loop []\n    (let [{:keys [posteriors likelihoods]} @gaussian-cache\n          observed-count (dec (count posteriors))]\n      (when (< observed-count target-posterior-count)\n        (let [likelihood (height-likelihood\n                          (nth adult-heights observed-count))\n              posterior (normalize-mean-one\n                         (mapv * (peek posteriors) likelihood))]\n          (reset! gaussian-cache\n                  {:posteriors (conj posteriors posterior)\n                   :likelihoods (conj likelihoods likelihood)})\n          (recur))))))"]]
+  [:p "Caching avoids recomputing earlier steps. Previous and Next only change which already reproducible update is displayed."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs"} "View the complete Gaussian-grid implementation and adult-height data"]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:details.bp-predict
+  [:summary "Predict before revealing: what will repeated heights do to the grid?"]
+  [:div
+   [:p "Before pressing Next, predict whether plausible parameter pairs will spread across the map or concentrate. Which direction should a relatively short height pull the mean?"]
+   [:p [:strong "Reveal by stepping:"] " the likelihood for one height is broad, but repeated multiplication concentrates posterior support where one mean–spread pair explains the complete dataset reasonably well."]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.bp-reading-guide
+  [:h3 "How to read the height simulator"]
+  [:ul
+   [:li "Horizontal position is candidate mean μ; vertical position is candidate standard deviation σ."]
+   [:li "Within each panel, stronger opacity means greater relative support. The scale is logarithmic."]
+   [:li "Compare location and concentration, not the absolute shade between different panels."]
+   [:li "Read left to right: posterior before this height, this height's likelihood, posterior after the update."]]])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -412,18 +565,78 @@
   [:script {:type "application/x-scittle"
             :src "bayes_theorem_simulations_interactive.cljs"}]])
 
-;; ## What this recreation is for
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:strong "Chapter 3 recap"]
+  [:p "Build: cross candidate means and standard deviations into a two-parameter grid. Check: inspect each likelihood and the before/after surfaces. Decide: retain the complete posterior surface, not only its highest cell."]])
+
+;; ## 4. Make the lesson reproducible
 ;;
-;; This is deliberately a record of my earlier learning. It does not
-;; silently turn these examples into the vocabulary estimator described in my
-;; first Civitas article; it exposes the probability tools that helped me get
-;; there.
+;; An executable article joins an explanation to calculations that can be run
+;; again. **Source code** is the human-readable set of instructions stored in
+;; the `.clj` and `.cljs` files. A **runtime** is the software environment that
+;; executes those instructions. **Browser state** is the current in-memory data
+;; behind controls, such as accumulated tosses or the selected step.
 ;;
+;; A **render** turns source into a reader-facing artifact. Here Clay evaluates
+;; the Clojure article using Kindly's display conventions and writes QMD
+;; (Quarto Markdown); Quarto turns QMD into HTML; Scittle executes the
+;; ClojureScript in the browser; Reagent updates semantic HTML and accessible
+;; SVG as browser state changes.
+
+^:kindly/hide-code
+(kind/mermaid
+ "flowchart LR
+    A[Clojure article] --> B[Clay / Kindly]
+    B --> C[QMD]
+    C --> D[Quarto HTML]
+    D --> E[Scittle / Reagent]
+    E --> F[semantic HTML + SVG]")
+
+^:kindly/hide-code
+(kind/hiccup
+ [:p.bp-engineering-caption
+  "The source-to-browser path. Clay, Scittle, and Quarto behavior follows their official documentation; links appear in Sources."])
+
+;; **Accessibility** means people can perceive and operate the article through
+;; different senses and input methods. Each SVG has a programmatic title and
+;; description; every control has a visible label and keyboard behavior; colour
+;; is paired with position, text, line style, or opacity; layouts reflow on
+;; narrow screens.
+;;
+;; A **regression check** asks whether an established property still holds
+;; after a change. The assertions below protect the 201-point grid, combinatorial
+;; count, normalisation, decision, and positive density. The browser checks add
+;; interaction, console, layout, focus, label, and theme verification. A random
+;; seed makes simulations replayable, so a changed result can be distinguished
+;; from ordinary random variation.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-browser-mounts"
+ "Mounting all three browser components"
+ [:div
+  [:p "A mount point is an empty, uniquely identified HTML element reserved for an interactive component. On page load, the browser finds each preserved ID and asks Reagent to render the matching component there."]
+  [:pre [:code "(defn ^:export mount []\n  (when-let [root (js/document.getElementById\n                   \"globe-update-simulator\")]\n    (rdom/render [globe-update-simulator] root))\n  (when-let [root (js/document.getElementById\n                   \"posterior-sampling-simulator\")]\n    (rdom/render [posterior-sampling-simulator] root))\n  (when-let [root (js/document.getElementById\n                   \"gaussian-height-simulator\")]\n    (rdom/render [gaussian-height-simulator] root)))"]]
+  [:p "The conditional lookup lets the same source load safely even if one mount is absent. The three IDs remain unchanged from the published article."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs"} "View the complete mounting and browser code"]]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:strong "From Bayes to vocabulary estimation"]
+  [:p "The next article reuses the same structure: candidate knowing rates receive priors; quiz responses supply likelihoods; posteriors predict untested items; seeded draws describe uncertainty; and an explicit stopping decision depends on the intended measurement task."]
+  [:p [:a {:href "beta_binomial_first_pass.html"} "Continue to the stratified Beta–binomial vocabulary model →"]]])
+
 ;; ## Sources
 ;;
 ;; - Jamie Pratt and the JointProb group, [original interactive simulations](https://jointprob.github.io/jointprob-shadow-cljs/#normal-distribution) and [ClojureScript source](https://github.com/jointprob/jointprob-shadow-cljs/tree/master/src/cljs).
-;; - Richard McElreath, *Statistical Rethinking*, examples from sections 2.2, 3.2, and 4.3. The prompts above are paraphrases.
-;; - [My first Civitas article: *Estimating Vocabulary Size with a Simple Bayesian Model*](beta_binomial_first_pass.html).
+;; - Richard McElreath, *Statistical Rethinking*, examples from sections 2.2, 3.2, and 4.3. The prompts here are paraphrases.
+;; - [Clay documentation](https://scicloj.github.io/clay/) on executable Clojure documents and Quarto output.
+;; - [Scittle documentation](https://scicloj.github.io/scittle/) on running ClojureScript in a browser.
+;; - [Quarto HTML documentation](https://quarto.org/docs/output-formats/html-basics.html) on rendering HTML output.
+;; - W3C Web Accessibility Initiative, [SVG accessibility guidance](https://www.w3.org/WAI/tutorials/images/tips/) and [accessible names and descriptions](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/).
 
 ^:kindly/hide-code
 (do
@@ -435,4 +648,7 @@
              1.0e-12))
   (assert (= 0.645 (first example-minimum-loss)))
   (assert (pos? (normal-density 151.765 155.0 8.0)))
-  :verified)
+  (kind/hiccup
+   [:p.bp-note
+    [:span.article-marker "Regression check"]
+    "All executable assertions passed."]))

--- a/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/bayes_theorem_simulations_interactive.cljs
@@ -83,6 +83,10 @@
 (defn counted-label [number singular]
   (str number " " singular (when (not= number 1) "s")))
 
+(defn modal-grid-value [values]
+  (let [index (first (apply max-key second (map-indexed vector values)))]
+    (nth probability-grid index)))
+
 ;; Accessible SVG primitives. The old application delegated these marks to
 ;; Vega; this recreation keeps the transformation visible in ClojureScript.
 
@@ -243,6 +247,39 @@
   (swap! update-state update :samples
          #(vec (drop-last (min amount (count %)) %))))
 
+(defn update-process-strip
+  [{:keys [prior latest counts likelihood raw-weights posterior]}]
+  (let [likelihood-mode (modal-grid-value likelihood)
+        raw-mode (modal-grid-value raw-weights)
+        posterior-mode (modal-grid-value posterior)
+        latest-label (case latest
+                       :water "latest: water"
+                       :land "latest: land"
+                       "waiting for data")]
+    [:div.bp-process-strip
+     {:role "img"
+      :aria-label
+      (str prior " prior multiplied by likelihood from " (:water counts)
+           " water and " (:land counts) " land observations; raw weights "
+           "are normalised to form a posterior peaking near p equals "
+           (format-decimal posterior-mode 3) ".")}
+     [:div.bp-process-step
+      [:strong "Prior"]
+      [:small prior]]
+     [:div.bp-process-symbol {:aria-hidden "true"} "×"]
+     [:div.bp-process-step
+      [:strong "Likelihood"]
+      [:small (str (:water counts) " W · " (:land counts) " L")]
+      [:small (str latest-label " · peak p ≈ " (format-decimal likelihood-mode 3))]]
+     [:div.bp-process-symbol {:aria-hidden "true"} "="]
+     [:div.bp-process-step
+      [:strong "Raw weights"]
+      [:small (str "peak p ≈ " (format-decimal raw-mode 3))]]
+     [:div.bp-process-symbol {:aria-label "then normalise"} "→"]
+     [:div.bp-process-step
+      [:strong "Posterior"]
+      [:small (str "normalised · peak p ≈ " (format-decimal posterior-mode 3))]]]))
+
 (defn globe-update-simulator []
   (let [{:keys [prior samples speed running?]} @update-state
         selected-prior (get priors-by-label prior)
@@ -264,6 +301,7 @@
         any-order-likelihood (normalize-mean-one
                               (mapv #(binomial-likelihood % (:water counts) (:land counts))
                                     probability-grid))
+        raw-posterior-weights (mapv * selected-prior any-order-likelihood)
         combination-count (binomial-coefficient (:n counts) (:water counts))]
     [:section.bp-shell {:aria-labelledby "globe-simulator-heading"}
      [:h3#globe-simulator-heading "Calculate a posterior distribution"]
@@ -310,6 +348,13 @@
       (if (seq samples)
         (str/join " " (map #(if (= % :water) "W" "L") samples))
         "No observations yet.")]
+     [update-process-strip
+      {:prior prior
+       :latest latest
+       :counts counts
+       :likelihood any-order-likelihood
+       :raw-weights raw-posterior-weights
+       :posterior current-posterior}]
      [:details.bp-details
       [:summary "Formulae for the current observations"]
       [:div
@@ -499,7 +544,7 @@
           ^{:key index}
           [:rect {:x x :y (- 220 height)
                   :width (max 1.2 (- (/ 550 posterior-bin-count) 0.2))
-                  :height height :fill "#2780e3" :fill-opacity 0.78}])
+                  :height height :fill "var(--bp-accent, #1464b5)" :fill-opacity 0.78}])
         (for [[p label] [[0 "0"] [0.25 ".25"] [0.5 ".50"] [0.75 ".75"] [1 "1"]]
               :let [x (+ 50 (* 550 p))]]
           ^{:key p}
@@ -685,7 +730,7 @@
                   y (+ 28 (* (- 40 row) cell-size))]]
         ^{:key index}
         [:rect {:x x :y y :width cell-size :height cell-size
-                :fill "#2780e3" :fill-opacity (heat-opacity value maximum)}])
+                :fill "var(--bp-accent, #1464b5)" :fill-opacity (heat-opacity value maximum)}])
       [:rect {:x 54 :y 28 :width (* 41 cell-size) :height (* 41 cell-size)
               :fill "none" :stroke "currentColor" :stroke-opacity 0.45}]
       (for [[mean label] [[150 "150"] [155 "155"] [160 "160"]]
@@ -706,7 +751,7 @@
       (for [index (range 10)
             :let [x (+ 297 (* index 9))]]
         ^{:key index}
-        [:rect {:x x :y 386 :width 9 :height 8 :fill "#2780e3"
+        [:rect {:x x :y 386 :width 9 :height 8 :fill "var(--bp-accent, #1464b5)"
                 :fill-opacity (+ 0.035 (* 0.965 (/ index 9)))}])
       [:text {:x 293 :y 393 :text-anchor "end" :font-size 9 :fill "currentColor"} "low"]
       [:text {:x 390 :y 393 :font-size 9 :fill "currentColor"} "high"]]]))

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
@@ -1,6 +1,7 @@
 ^{:kindly/hide-code true
   :kindly/options {:html/deps [:scittle :reagent]}
-  :clay {:title "Estimating Vocabulary Size with a Simple Bayesian Model"
+  :clay {:hide-info-line true
+         :title "Estimating Vocabulary Size: A Stratified Beta–Binomial First Pass"
          :quarto {:author :jamiep
                   :description "A learning-in-public first pass at estimating receptive vocabulary from stratified responses with a Beta–binomial model."
                   :type :post
@@ -17,10 +18,40 @@
 ^:kindly/hide-code
 (kind/hiccup
  [:style
-  "#title-block-header{padding-top:.75rem}#title-block-header h1{line-height:1.15;overflow-wrap:anywhere}.ve-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.25rem}.ve-callout.provisional{border-color:#e69f00;background:#fff8e6}.ve-callout strong{display:block;margin-bottom:.3rem}.ve-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}.ve-card{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:1rem;background:var(--bs-body-bg,#fff)}.ve-card h3{font-size:1rem;margin-top:0}.ve-table-wrap{overflow-x:auto;margin:1.25rem 0}.ve-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}.ve-table th,.ve-table td{padding:.55rem .7rem;border-bottom:1px solid #dee2e6;text-align:right;white-space:nowrap}.ve-table th:first-child,.ve-table td:first-child{text-align:left}.ve-table thead th{border-bottom:2px solid #adb5bd}.ve-figure{margin:1.5rem 0;padding:1rem;border:1px solid #dee2e6;border-radius:.5rem}.ve-figure svg{display:block;width:100%;height:auto}.ve-caption{font-size:.9rem;color:#4f5b66;margin:.75rem 0 0}.quarto-dark .ve-caption{color:#b9c7d2}.ve-simulator{margin:1.5rem 0}.ve-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}@media(max-width:575px){.ve-table th,.ve-table td{padding:.45rem}.ve-figure{padding:.65rem}}"])
+  (str
+   ":root{--ve-accent:#1464b5;--ve-accent-soft:#e5f1fb;--ve-warm:#9a4b00;--ve-warm-soft:#fff0df;--ve-purple:#694aa6;--ve-muted:#4f5b66}"
+   ".quarto-dark{--ve-accent:#73b7ff;--ve-accent-soft:#173653;--ve-warm:#ffc27a;--ve-warm-soft:#4a2d12;--ve-purple:#c5a7ff;--ve-muted:#b9c7d2}"
+   "#title-block-header{padding-top:.75rem}#title-block-header h1{line-height:1.15;overflow-wrap:anywhere}"
+   "mjx-container[display=true]{max-width:100%;overflow-x:auto;overflow-y:hidden}"
+   ".ve-callout{border:1px solid color-mix(in srgb,var(--ve-accent) 45%,var(--bs-border-color,#dee2e6));border-left:4px solid var(--ve-accent);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--ve-accent) 10%);color:var(--bs-body-color,#212529);padding:1rem 1.15rem;margin:1.4rem 0;border-radius:.35rem}"
+   ".ve-callout.provisional{border-color:color-mix(in srgb,var(--ve-warm) 60%,var(--bs-border-color,#dee2e6));border-left-color:var(--ve-warm);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--ve-warm) 10%)}"
+   ".ve-callout strong{display:block;margin-bottom:.3rem}.ve-callout p:last-child{margin-bottom:0}"
+   ".ve-grid,.ve-definition-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:.75rem;margin:1.25rem 0}"
+   ".ve-card,.ve-definition{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.5rem;padding:.85rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529);overflow-wrap:anywhere}"
+   ".ve-card h3{font-size:1rem;margin-top:0}.ve-definition dt{font-weight:800;color:var(--ve-accent)}.ve-definition dd{margin:.25rem 0 0}"
+   ".ve-table-wrap{max-width:100%;overflow-x:auto;margin:1.25rem 0}.ve-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}"
+   ".ve-table th,.ve-table td{padding:.55rem .7rem;border-bottom:1px solid var(--bs-border-color,#dee2e6);text-align:right;white-space:nowrap}.ve-table th:first-child,.ve-table td:first-child{text-align:left}.ve-table thead th{border-bottom:2px solid var(--bs-border-color,#adb5bd)}"
+   ".ve-figure{margin:1.5rem 0;padding:1rem;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.5rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-figure svg{display:block;width:100%;height:auto}"
+   ".ve-caption,.ve-note{font-size:.9rem;color:var(--ve-muted);margin:.75rem 0 0}.ve-simulator{margin:1.5rem 0}"
+   ".ve-reading-guide{border-left:4px solid var(--ve-accent);padding:.2rem 0 .2rem 1rem;margin:1rem 0}.ve-reading-guide h3{font-size:1rem;margin:.1rem 0 .35rem}.ve-reading-guide ul{margin-bottom:.2rem}"
+   ".ve-hierarchy{display:grid;grid-template-columns:minmax(8rem,.7fr) auto minmax(0,1.5fr);gap:.7rem;align-items:center}.ve-hierarchy-node{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.7rem;text-align:center;background:var(--bs-body-bg,#fff);overflow-wrap:anywhere}.ve-hierarchy-node strong{display:block;color:var(--ve-accent)}"
+   ".ve-hierarchy-arrow{font-size:1.5rem;color:var(--ve-accent);font-weight:800}.ve-form-list{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.5rem}.ve-sense-gap{grid-column:1/-1;border:2px dashed var(--ve-warm);border-radius:.45rem;padding:.65rem;text-align:center;color:var(--bs-body-color,#212529);background:color-mix(in srgb,var(--bs-body-bg,#fff) 92%,var(--ve-warm) 8%)}"
+   ".ve-workflow-caption{text-align:center;color:var(--ve-muted);font-size:.88rem}.ve-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}"
+   "@media(max-width:767px){.ve-hierarchy{grid-template-columns:minmax(0,1fr)}.ve-hierarchy-arrow{transform:rotate(90deg);text-align:center}.ve-form-list{grid-template-columns:minmax(0,1fr)}}"
+   "@media(max-width:575px){.ve-table th,.ve-table td{padding:.45rem}.ve-figure{padding:.65rem}}")])
 
 ^:kindly/hide-code
 (math/styles)
+
+^:kindly/hide-code
+(kind/hiccup
+ [:style
+  (str
+   ".ve-round-shell,.ve-stop-shell{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+   ".ve-round-shell h3,.ve-stop-shell h3{margin-top:0}.ve-round-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.55rem;margin:1rem 0}.ve-round-card{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.65rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 94%,var(--ve-accent) 6%);overflow-wrap:anywhere}.ve-round-card strong,.ve-round-card span,.ve-round-card small{display:block}.ve-round-card small{color:var(--ve-muted);margin-top:.25rem}.ve-round-progress{width:100%;height:.55rem;accent-color:var(--ve-accent)}.ve-round-status{min-height:2.8rem;font-variant-numeric:tabular-nums}"
+   ".ve-stop-banner{display:flex;align-items:baseline;gap:.35rem;flex-wrap:wrap;border-left:4px solid var(--ve-accent);border-radius:.35rem;padding:.65rem .8rem;margin:.8rem 0;background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--ve-accent) 10%)}.ve-stop-banner.is-counterfactual{border-left-color:var(--ve-warm);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--ve-warm) 10%)}"
+   ".ve-stop-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:.8rem;margin:1rem 0}.ve-stop-field{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.65rem}.ve-stop-field>div{display:flex;justify-content:space-between;align-items:baseline;gap:.5rem}.ve-stop-field label{font-weight:700}.ve-stop-field output{font-variant-numeric:tabular-nums;color:var(--ve-muted);text-align:right}.ve-stop-field input{width:100%;accent-color:var(--ve-accent)}.ve-stop-result{border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.75rem;margin:1rem 0}.ve-stop-result ul{margin:.5rem 0 0}.ve-sampling-button:disabled{opacity:.5;cursor:not-allowed}.ve-stop-field input:focus-visible{outline:3px solid color-mix(in srgb,var(--ve-accent) 50%,transparent);outline-offset:3px}"
+   "@media(max-width:767px){.ve-round-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:400px){.ve-round-grid{grid-template-columns:minmax(0,1fr)}}")])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -31,20 +62,17 @@
 (kind/hiccup
  [:nav.series-toc {:aria-labelledby "series-contents-heading"}
   [:h2#series-contents-heading "Series contents"]
-  [:p
-   [:strong "Revisiting basic Bayes' theorem and applying it to a real word problem: estimating vocabulary size from "]
-   [:a {:href "https://lexibench.com/"} "Lexibench.com"]
-   [:strong " quiz responses."]]
+  [:p "The second article applies the previous Bayesian tools to one deliberately narrow measurement problem."]
   [:ol
    [:li [:a {:href "bayes_theorem_simulations.html"}
-         "Bayes' Theorem, Revisited: Three Interactive Simulations"]
+         "Bayes' theorem from uncertainty to decision"]
     [:span.series-status "published"]]
    [:li [:a {:href "beta_binomial_first_pass.html"}
-         "Estimating Vocabulary Size with a Simple Bayesian Model"]
-    [:span.series-status "published"]]
+         "Estimating vocabulary size: a stratified Beta–binomial first pass"]
+    [:span.series-status "you are here"]]
    [:li [:a {:href "pair_frequency_logistic_v2_article.html"}
-         "Does Pair Frequency Predict Learner Responses?"]
-    [:span.series-status "published"]]
+         "Does pair frequency predict learner responses?"]
+    [:span.series-status "next"]]
    [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
     [:span.series-status "planned"]]
    [:li "From Correlated Form Pairs to Latent Lemma Knowledge"
@@ -59,45 +87,46 @@
 ^:kindly/hide-code
 (math/global-controls)
 
-;; I am building [**Lexibench**](https://lexibench.com/), a vocabulary-testing
-;; product. Much of its user interface is already in place, but its scorer is
-;; being replaced. The model in this post is a deliberately small first pass: it
-;; is **not deployed in Lexibench**.
+;; A test result is meaningful only after its target is defined. **Measurement**
+;; is the disciplined act of connecting recorded observations to that target.
+;; It is not the same as attaching a number to a person.
 ;;
-;; I reached it through an unusually useful learning loop. Codex acts as a tutor
-;; and makes visual explanations; I annotate those explanations in Codex's
-;; internal browser; then
-;; we repeat. Each pass exposes a mistaken assumption or a word I was using too
-;; casually.
-;;
-;; I find it very pleasant and easier to interact with HTML explanations,
-;; including diagrams, instead of a wall of text.
+;; I am building [**Lexibench**](https://lexibench.com/), but the model in this
+;; article is a historical first-pass target scorer. It is **not a description
+;; of the scorer currently deployed at Lexibench**. Correct probability
+;; calculations cannot rescue a vague target or an unsuitable item pool.
 
 ^:kindly/hide-code
-(kind/mermaid
- "flowchart LR
-    Q[Jamie asks a question] --> T[Codex tutors and builds a visual explanation]
-    T --> A[Jamie annotates it in Codex's internal browser]
-    A --> R[Codex revises the explanation]
-    R --> U[Understanding improves]
-    U --> Q")
+(kind/hiccup
+ [:ol.article-chapter-map
+  [:li [:strong "Define"] [:br] "What exactly would the reported count mean?"]
+  [:li [:strong "Sample"] [:br] "How can eight balanced strata represent a fixed pool?"]
+  [:li [:strong "Update"] [:br] "How do responses change uncertainty within each stratum?"]
+  [:li [:strong "Predict"] [:br] "How do tested and untested pairs combine into a finite total?"]
+  [:li [:strong "Decide"] [:br] "When is the estimate precise enough to stop?"]
+  [:li [:strong "Reproduce"] [:br] "How do fixtures, seeds, tests, and publication gates protect the result?"]])
 
-;; This article records where that loop has taken me so far. I will distinguish
-;; **verified mathematics** from **provisional modelling choices** throughout.
-;; The distinction matters: correct algebra cannot make a poorly defined target
-;; meaningful.
+;; ## 1. Define: what is being measured?
 ;;
-;; ## First define what is being estimated
+;; The casual question “How many words do you know?” hides several choices.
+;; Does *ran* count separately from *run*? Does one meaning of *bank* count
+;; separately from another? Which language inventory supplies the denominator?
+;; This first pass cannot answer every version of that question. It answers one
+;; narrower, reproducible version.
 ;;
 ;; The estimand here is:
 ;;
 ;; > **Receptive knowledge of lemma–surface-form pairs in a fixed, versioned
 ;; > pool.**
 ;;
-;; A lemma such as *run* may have several surface forms. The frequency data I
-;; have for a pair does not distinguish senses. Each pair therefore gets one
-;; canonical item in context. The context and translation select an intended
-;; meaning for that item, but they remain **measurement metadata**; this model
+;; A lemma such as *run* may have several surface forms. The NKJP and SUBTLEX
+;; frequency data used to rank a pair does not distinguish senses. The item
+;; curation process mitigates this by rejecting ambiguous or overly
+;; context-dependent pairs and placing each remaining surface form in a short,
+;; commonly heard sentence showing a normal use. This makes unusual senses less
+;; likely to add difficulty, but it is a design safeguard, not evidence that
+;; sense has no effect. The context and translation select an intended meaning
+;; for the canonical item, but they remain **measurement metadata**; this model
 ;; does not pretend it has estimated sense-specific knowledge.
 
 ^:kindly/hide-code
@@ -107,14 +136,38 @@
  "Language terms"
  "Lexical terms used in this model"
  [["Receptive knowledge" "Recognising and understanding a form when it is encountered, rather than being able to produce it unaided."]
+  ["Estimand" "The precisely defined quantity a measurement procedure aims to estimate. Here it is a count of known lemma–surface-form pairs in one fixed pool."]
   ["Lemma" "A dictionary headword used to group related inflected forms. For example, the English lemma run groups forms such as run, runs, ran, and running."]
   ["Surface form" "The exact written form that appears in text or in a question, such as ran or running."]
   ["Lemma–surface-form pair" "One lemma ID linked to one surface-form ID—the countable unit in this model. For example: lemma run + surface form ran."]
   ["Sense" "One distinct meaning of a lemma, such as run meaning “move quickly” versus a machine that “runs.” The frequency table has no sense IDs, so the model cannot estimate sense-specific knowledge."]
   ["Canonical item" "One fixed, versioned quiz question for a pair. Its context selects the intended meaning for measurement, but does not create a sense-specific frequency count."]])
 
-;; This is narrower than “How many words do you know?” That narrowing is useful:
-;; it gives the count a denominator, a pool version, and a repeatable item.
+^:kindly/hide-code
+(kind/hiccup
+ [:figure.ve-figure
+  [:div.ve-hierarchy
+   {:role "img"
+    :aria-label "The lemma run links to four separately counted lemma–surface-form pairs: run, runs, ran, and running. NKJP and SUBTLEX pair frequencies have no sense identifier; item curation favours common, everyday usage to reduce sense-related difficulty."}
+   [:div.ve-hierarchy-node [:strong "Lemma"] "run"]
+   [:div.ve-hierarchy-arrow {:aria-hidden "true"} "→"]
+   [:div.ve-form-list
+    [:div.ve-hierarchy-node [:strong "Pair 1"] "run + run"]
+    [:div.ve-hierarchy-node [:strong "Pair 2"] "run + runs"]
+    [:div.ve-hierarchy-node [:strong "Pair 3"] "run + ran"]
+    [:div.ve-hierarchy-node [:strong "Pair 4"] "run + running"]
+    [:div.ve-sense-gap
+     [:strong "Missing layer: senses"]
+     [:br]
+     "NKJP and SUBTLEX pair frequencies have no sense ID. Item curation favours common, everyday usage to reduce sense-related difficulty, but the pair count is not sense-specific."]]]
+  [:figcaption.ve-caption
+   "The estimand counts the four lemma–form pairs separately. It does not claim four independent lemmas or sense-specific frequencies."]])
+
+;; This target **can** support a qualified statement such as “estimated known
+;; pairs in pool P, version V, under algorithm A.” It **cannot** by itself report
+;; a universal count of “words known,” productive vocabulary, sense-specific
+;; knowledge, or overall language proficiency. The narrowing is useful because
+;; it supplies a denominator, a pool version, and repeatable items.
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -128,12 +181,16 @@
   [:strong "Provisional modelling choice"]
   "Provisional means chosen as a testable starting assumption, not established by the data. The pair inventory, canonical contexts, frequency strata, response mapping, prior, and stopping threshold all need empirical validation."])
 
-;; ## A simplified non-adaptive test
+;; ## 2. Sample: balanced rounds from a fixed pool
 ;;
 ;; For exposition, imagine a fixed, versioned pool split by frequency rank into eight
 ;; strata with the same number of pairs. A round samples one item uniformly at
 ;; random from each stratum. Later answers do not change which item is selected:
 ;; **selection remains non-adaptive**.
+;;
+;; The full pool is the **population** about which this test makes its claim. The
+;; much smaller set of administered items is the **sample**. Sampling is needed
+;; because asking all 8,000 questions would defeat the purpose of an estimate.
 
 ^:kindly/hide-code
 (math/terminology
@@ -142,6 +199,8 @@
  "Test-design terms"
  "Terms used in the selection schedule"
  [["Pool" "The complete fixed, versioned set of lemma–surface-form pairs that this test is allowed to estimate."]
+  ["Population" "Every pair in the fixed pool about which this particular estimate makes a claim."]
+  ["Sample" "The smaller set of pool items actually administered to the learner."]
   ["Pair" "Shorthand here for one lemma–surface-form pair—not two arbitrary words and not a word sense."]
   ["Frequency rank" "The position of a pair after ordering the source corpus data from most frequent to least frequent. Rank 1 is most frequent; rank is a proxy, not calibrated learner difficulty."]
   ["Stratum" "One of eight equal-count bands formed from adjacent frequency ranks." "strata"]
@@ -186,12 +245,40 @@
  [:p.ve-caption
   "Frequency rank partitions the illustrative pool; this diagram does not claim that rank is a calibrated item-difficulty scale."])
 
+;; **Frequency rank** is only a proxy: a convenient observable used in place of
+;; an unobserved quantity. Here it stands in for item difficulty, but it has not
+;; been calibrated against learner responses. Equal-count strata balance the
+;; sample across that proxy; they do not prove equal difficulty inside a band.
+;;
+;; ### Watch the fixed schedule
+;;
+;; Select items one at a time below. Read across the eight cards: each round
+;; takes exactly one unseen item from every stratum. The sample responses are
+;; shown, but the “next item” labels advance according to the pre-existing
+;; queues, never according to those responses.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.ve-simulator
+  [:div#balanced-round-simulator
+   [:p "Loading the balanced-round demonstration…"]]
+  [:noscript "This animation needs JavaScript. The fixed eight-stratum schedule above remains authoritative."]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:span.article-marker "Build / Check / Decide"]
+  [:p "Build: version a finite population and queue unseen items in eight frequency bands. Check: every completed round contains one item from each band, with no repeats. Decide: keep selection non-adaptive until a learner-calibrated difficulty model exists."]])
+
+;; ## 3. Record first, collapse only for v1 inference
+;;
 ;; The interface keeps three raw response values:
 ;; `:correct`, `:wrong`, and `:dont-know`. Stage one maps a correct response to
 ;; “known” and both other responses to “not known.” Keeping the raw outcomes
 ;; distinct lets a later model treat guessing, slips, and explicit uncertainty
 ;; differently without corrupting the original data.
 
+^:kindly/hide-code
 (defn collapse-response
   "Map a raw response to the binary stage-one likelihood outcome."
   [response]
@@ -203,19 +290,39 @@
                     {:response response
                      :allowed #{:correct :wrong :dont-know}}))))
 
+^:kindly/hide-code
 (defn collapse-responses
   "Return the sufficient statistics {:k correct :n attempted}."
   [responses]
   {:k (reduce + (map collapse-response responses))
    :n (count responses)})
 
-(into {} (map (juxt identity collapse-response)
-              [:correct :wrong :dont-know]))
-
-;; The output confirms that `:wrong` and `:dont-know` remain different raw keys
-;; even though their stage-one likelihood contribution is the same.
+;; The mapping keeps `:wrong` and `:dont-know` as different raw keys even though
+;; their stage-one likelihood contribution is the same.
 ;;
-;; ## One stratum: Beta in, Beta out
+;; A **Bernoulli trial** has two outcomes for this model: 1 for correct and 0
+;; for not correct. That binary value is derived for inference; it does not
+;; overwrite the original event. This separation is what permits a later model
+;; to distinguish a wrong answer from an explicit “don't know.”
+
+^:kindly/hide-code
+(math/code-detail
+ "code-raw-response-mapping"
+ "Mapping raw responses without discarding the events"
+ [:div
+  [:p "The pure function returns the v1 binary outcome. Unknown values fail loudly instead of silently entering the model."]
+  [:pre [:code "(defn collapse-response [response]\n  (case response\n    :correct 1\n    :wrong 0\n    :dont-know 0\n    (throw (ex-info \"Unknown raw response\"\n                    {:response response}))))"]]
+  [:p "Storage retains the original keyword; only the input to this first inference model is collapsed."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the executable article source"]]])
+
+;; ## 4. Update: Beta in, Beta out within one stratum
+;;
+;; A sequence of Bernoulli trials can be summarized by a **binomial count**:
+;; $k$ correct responses among $n$ attempts. A **Beta distribution** describes
+;; uncertainty about a probability between 0 and 1. It has two positive shape
+;; parameters, $\alpha$ and $\beta$. Choosing a Beta prior makes the update
+;; **conjugate**: after binomial data, the posterior is another Beta
+;; distribution, so no numerical approximation is needed for this step.
 ;;
 ;; Let $p_s$ be the knowing rate in stratum $s$. This first pass gives every
 ;; stratum the same prior:
@@ -239,6 +346,11 @@
 ;; proportional to $p_s^k(1-p_s)^{n-k}$, so:
 ;;
 ;; $$p_s \mid k,n \sim \operatorname{Beta}(1+k,1+n-k).$$
+;;
+;; Read this as: “start with one prior count on each side; add the $k$
+;; correct responses to $\alpha$ and the $n-k$ not-correct responses to
+;; $\beta$.” For example, three correct among four attempts changes
+;; `Beta(1,1)` into `Beta(4,2)`.
 
 ^:kindly/hide-code
 (math/explanation
@@ -254,6 +366,7 @@
   ["Beta(…)" "The posterior stays in the Beta family because the Beta prior is conjugate to the Bernoulli/binomial likelihood."]]
  "The complete response history reduces to k and n for this update, although the original correct, wrong, and don’t-know events remain stored separately.")
 
+^:kindly/hide-code
 (defn posterior-parameters
   "Beta posterior parameters for a Beta(alpha,beta) prior and k of n correct."
   ([k n] (posterior-parameters 1.0 1.0 k n))
@@ -262,18 +375,36 @@
    {:alpha (+ alpha k)
     :beta (+ beta (- n k))}))
 
-(posterior-parameters 3 4)
+^:kindly/hide-code
+(math/code-detail
+ "code-beta-posterior-parameters"
+ "Updating the two Beta shape parameters"
+ [:div
+  [:p "This function is pure: the same prior and counts always return the same posterior parameters, and no external state changes."]
+  [:pre [:code "(defn posterior-parameters\n  ([k n] (posterior-parameters 1.0 1.0 k n))\n  ([alpha beta k n]\n   {:pre [(<= 0 k n) (pos? alpha) (pos? beta)]}\n   {:alpha (+ alpha k)\n    :beta (+ beta (- n k))}))"]]
+  [:p "The precondition rejects impossible counts and non-positive Beta parameters before they can contaminate a result."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the complete posterior update"]]])
 
-;; `{:alpha 4.0, :beta 2.0}` is the entire update. “Posterior” names the
+;; `{:alpha 4.0, :beta 2.0}` is the entire update for three correct among four.
+;; “Posterior” names the
 ;; updated density for $p_s$. The “likelihood” is the information supplied by
 ;; the last response as a function of $p_s$; it is not itself a posterior.
 ;;
 ;; ### Try the update
 ;;
-;; Press **Correct** or **Don't know**. The accessible SVG compares the uniform
+;; Press **Correct**, **Wrong**, or **Don't know**. The accessible SVG compares the uniform
 ;; prior, the previous posterior, the last-response likelihood, and the current
 ;; posterior. Curve height is **density**, not the probability of one exact
 ;; value of $p$.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.ve-reading-guide
+  [:h3 "How to read the chart"]
+  [:ul
+   [:li "Horizontal position is a candidate knowing rate from 0 to 1."]
+   [:li "Curve height is probability density: where the distribution concentrates, not the probability of one exact decimal."]
+   [:li "The solid current curve is the result after the latest response; the dashed curves show what was multiplied to obtain it."]]])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -282,7 +413,7 @@
    [:p "Loading the Bayesian update simulator…"]]
   [:noscript "This simulator needs JavaScript. The statistical core above remains readable without it."]])
 
-;; ## From a knowing rate to a vocabulary total
+;; ## 5. Predict: from knowing rates to an untested finite pool
 ;;
 ;; For a stratum containing $N_s$ pairs, of which $n_s$ were tested and $k_s$
 ;; were correct:
@@ -293,10 +424,33 @@
 ;; 3. add the $k_s$ observed correct pairs;
 ;; 4. sum the eight stratum totals.
 ;;
+;; $$U_s \mid p_s \sim \operatorname{Binomial}(N_s-n_s,p_s),
+;; \qquad T=\sum_{s=1}^{8}(k_s+U_s).$$
+;;
+;; Read this as: “predict $U_s$ known pairs only among the $N_s-n_s$ untested
+;; pairs; add the already observed correct pairs $k_s$ once; then sum all eight
+;; strata.” Tested-not-correct pairs contribute zero and are never predicted
+;; again. This avoids both double counting and pretending an observed response
+;; is still unknown.
+
+^:kindly/hide-code
+(math/explanation
+ "math-finite-pool-prediction"
+ "Posterior prediction for the remaining finite pool"
+ [["U_s" "The predicted number known among the untested pairs in stratum s."]
+  ["N_s" "The fixed number of pairs in stratum s."]
+  ["n_s" "The number of pairs already tested in stratum s."]
+  ["p_s" "One knowing rate drawn from stratum s's Beta posterior."]
+  ["k_s" "The observed correct count, added directly rather than predicted again."]
+  ["T" "One complete posterior-predictive draw of total known pairs across all eight strata."]
+  ["Σ" "Sum the parenthesized stratum total for s = 1 through 8."]]
+ "The binomial draw concerns exactly the untested finite remainder, not a new infinite population and not the tested items.")
+;;
 ;; The following functions are the executable version. Fastmath supplies the
 ;; Beta and binomial distributions; a seeded Mersenne Twister makes the rendered
 ;; result reproducible.
 
+^:kindly/hide-code
 (defn posterior-predictive-stratum
   "Draw known pairs in one stratum, including observed correct pairs."
   [rng {:keys [pool-size k n]}]
@@ -309,6 +463,7 @@
                                        {:trials untested :p p :rng rng})]
     (+ k (random/sample predicted))))
 
+^:kindly/hide-code
 (defn posterior-predictive-total
   "Draw and sum known-pair counts across strata."
   ([strata] (posterior-predictive-total 20260712 strata))
@@ -316,6 +471,17 @@
    (let [rng (random/rng :mersenne seed)]
      (reduce + (mapv #(posterior-predictive-stratum rng %) strata)))))
 
+^:kindly/hide-code
+(math/code-detail
+ "code-finite-pool-draw"
+ "Making one finite-pool posterior-predictive draw"
+ [:div
+  [:p "The draw keeps the three groups separate: observed correct, observed not-correct, and untested. Only the untested group is simulated."]
+  [:pre [:code "(defn posterior-predictive-stratum\n  [rng {:keys [pool-size k n]}]\n  (let [{:keys [alpha beta]} (posterior-parameters k n)\n        p (random/sample\n           (random/distribution :beta\n             {:alpha alpha :beta beta :rng rng}))\n        untested (- pool-size n)\n        predicted (random/sample\n                   (random/distribution :binomial\n                     {:trials untested :p p :rng rng}))]\n    (+ k predicted)))"]]
+  [:p "A random seed initializes the pseudo-random generator. Supplying the same fixture and seed reproduces the same draw sequence."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the complete seeded prediction functions"]]])
+
+^:kindly/hide-code
 (defn quantile
   "Nearest-rank-style quantile from a finite numeric sample."
   [xs probability]
@@ -324,6 +490,7 @@
         i (long (Math/floor (* probability (dec (count ordered)))))]
     (nth ordered i)))
 
+^:kindly/hide-code
 (defn equal-tail-quantiles
   "Return the central equal-tail interval from a finite sample."
   ([xs] (equal-tail-quantiles xs 0.95))
@@ -332,30 +499,53 @@
      {:lower (quantile xs tail)
       :upper (quantile xs (- 1.0 tail))})))
 
-;; ## Worked example: a pedagogical 8,000-pair pool
+^:kindly/hide-code
+(math/code-detail
+ "code-quantile-selection"
+ "Selecting equal-tail interval endpoints"
+ [:div
+  [:p "Sort the finite totals, convert a probability to an index, and select that ordered value. A 95% equal-tail interval uses probabilities 0.025 and 0.975."]
+  [:pre [:code "(defn quantile [xs probability]\n  (let [ordered (vec (sort xs))\n        i (long (Math/floor\n                 (* probability (dec (count ordered)))))]\n    (nth ordered i)))\n\n(equal-tail-quantiles draws 0.95)"]]
+  [:p "This function selects quantiles from Monte Carlo draws. The exact reference interval below instead selects where the cumulative exact discrete probability crosses the same two cut points."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the quantile implementation"]]])
+
+;; ## 6. Combine: a pedagogical 8,000-pair pool
 ;;
 ;; **8,000 is an illustration, not a current CEFR or Lexibench pool size.** It
 ;; consists of eight 1,000-pair strata. After four complete rounds, suppose the
 ;; correct counts are `[4 4 3 3 2 1 1 0]`.
 
+^:kindly/hide-code
 (def worked-correct-counts [4 4 3 3 2 1 1 0])
 
+^:kindly/hide-code
 (def worked-strata
   (mapv (fn [k] {:pool-size 1000 :k k :n 4})
         worked-correct-counts))
 
+^:kindly/hide-code
 (defn analytic-stratum-mean
   "Posterior-predictive mean for one stratum."
   [{:keys [pool-size k n]}]
   (let [{:keys [alpha beta]} (posterior-parameters k n)]
     (+ k (* (- pool-size n) (/ alpha (+ alpha beta))))))
 
+^:kindly/hide-code
+(math/code-detail
+ "code-analytic-stratum-mean"
+ "Calculating a stratum's posterior-predictive mean"
+ [:div
+  [:p "The Beta posterior mean is alpha divided by alpha plus beta. Multiply it by the untested count, then add observed correct pairs exactly once."]
+  [:pre [:code "(defn analytic-stratum-mean\n  [{:keys [pool-size k n]}]\n  (let [{:keys [alpha beta]}\n        (posterior-parameters k n)]\n    (+ k\n       (* (- pool-size n)\n          (/ alpha (+ alpha beta))))))"]]
+  [:p "This is analytic: it follows directly from the distribution's expectation and has no simulation noise."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the worked calculation"]]])
+
+^:kindly/hide-code
 (def worked-analytic-mean
   (long (reduce + (map analytic-stratum-mean worked-strata))))
 
-worked-analytic-mean
-
-;; The posterior-predictive mean is **4,334 pairs**. Row by row:
+;; The **mean** is the probability-weighted average of all possible totals under
+;; the model. It is **4,334 pairs** here. Row by row:
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -385,8 +575,34 @@ worked-analytic-mean
      [:td "—"]
      [:td (format "%,d" worked-analytic-mean)]]]]])
 
-;; The exact discrete posterior-predictive distribution gives a 95% equal-tail
-;; credible interval of **3,404–5,249**. Reader-facing, I would report:
+;; A point mean hides **uncertainty**: the model still supports a range of
+;; totals. Here an exact calculation is possible because every stratum has a
+;; finite number of outcomes. For each possible untested count $x$, the
+;; Beta–binomial probability is
+;;
+;; $$P(U_s=x\mid k_s,n_s)=
+;; {m_s \choose x}
+;; \frac{B(x+\alpha_s,m_s-x+\beta_s)}{B(\alpha_s,\beta_s)},
+;; \qquad m_s=N_s-n_s.$$
+;;
+;; Read this as: “assign an exact probability to every possible known count
+;; among the untested pairs, using the updated Beta uncertainty.” Convolving—the
+;; discrete equivalent of adding—all eight probability lists produces an exact
+;; distribution for the total. The **95% equal-tail credible interval** removes
+;; 2.5% probability from each tail. Its endpoints are **3,404–5,249**.
+
+^:kindly/hide-code
+(math/explanation
+ "math-beta-binomial-pmf"
+ "Exact probability of one untested stratum count"
+ [["P(U_s = x | k_s,n_s)" "The posterior-predictive probability that exactly x untested pairs are known in stratum s."]
+  ["m_s" "The untested remainder N_s − n_s; 996 in every worked-example stratum."]
+  ["choose(m_s,x)" "The number of ways x known outcomes can occur among m_s untested pairs."]
+  ["B(·,·)" "The Beta function; the ratio integrates over uncertainty in p_s rather than plugging in one rate."]
+  ["α_s, β_s" "The two posterior Beta parameters for stratum s."]]
+ "Calculating all x values and adding the eight independent stratum distributions yields the exact finite-pool total distribution.")
+;;
+;; Reader-facing, I would report:
 ;;
 ;; > **About 4,330 known pairs, with a 95% credible interval of roughly
 ;; > 3,400–5,250, conditional on this model and fixed pool.**
@@ -436,8 +652,17 @@ worked-analytic-mean
 
 ^:kindly/hide-code
 (kind/hiccup
+ [:div.ve-reading-guide
+  [:h3 "How to read the posterior-predictive simulator"]
+  [:ul
+   [:li "In the newest draw, each row separates tested correct, tested not-correct, and predicted untested pairs."]
+   [:li "The tested groups are fixed by observed events. Only the untested count is drawn."]
+   [:li "In the lower chart, one dot is one complete eight-stratum total; the line and marker summarize only the visible dots."]]])
+
+^:kindly/hide-code
+(kind/hiccup
  [:style
-  ".ve-posterior-sampler{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.ve-sampling-intro{max-width:50rem}.ve-sampling-controls{display:flex;align-items:end;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin:1rem 0}.ve-rate-fieldset{border:0;padding:0;margin:0;min-width:0}.ve-rate-fieldset legend{font-size:.85rem;font-weight:700;margin-bottom:.4rem}.ve-button-row{display:flex;gap:.5rem;flex-wrap:wrap}.ve-sampling-button{border:1px solid #6c757d;border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-sampling-button[aria-pressed=true],.ve-sampling-button.ve-primary{border-color:#1464b5;background:#1464b5;color:#fff}.ve-sampling-button:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 45%,transparent);outline-offset:2px}.ve-sampling-progress{width:100%;height:.55rem;accent-color:#2780e3}.ve-sampling-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1rem;margin-top:1rem}.ve-sample-panel{min-width:0;border:1px solid #dee2e6;border-radius:.5rem;padding:clamp(.65rem,2vw,1rem);margin:0}.ve-sample-panel h4{font-size:1rem;margin:0 0 .25rem}.ve-sample-panel svg{display:block;width:100%;height:auto}.ve-sample-stat{font-variant-numeric:tabular-nums;margin:.2rem 0 .65rem}.ve-sample-note{font-size:.85rem;color:#4f5b66;margin:.5rem 0 0}.ve-empty-sample{display:grid;place-items:center;min-height:13rem;border:1px dashed #adb5bd;border-radius:.35rem;color:#4f5b66;text-align:center;padding:1rem}.quarto-dark .ve-sample-note,.quarto-dark .ve-empty-sample{color:#b9c7d2}.ve-sampling-status{font-variant-numeric:tabular-nums;margin:.4rem 0}.ve-dot{fill:#2780e3;fill-opacity:.72}.ve-dot-latest{fill:#c44536;stroke:var(--bs-body-bg,#fff);stroke-width:1.5}.ve-sample-axis{stroke:currentColor;stroke-opacity:.45}.ve-sample-guide{stroke:currentColor;stroke-opacity:.1}.ve-latest-line{stroke:#2780e3;stroke-width:5;stroke-linecap:round}.ve-latest-dot{fill:#c44536;stroke:var(--bs-body-bg,#fff);stroke-width:2}@media(max-width:575px){.ve-sampling-controls{align-items:stretch}.ve-sampling-controls>.ve-button-row{width:100%}.ve-sampling-controls>.ve-button-row .ve-sampling-button{flex:1}.ve-sampling-button{padding:.55rem .7rem}}"])
+  ".ve-posterior-sampler{border:1px solid var(--bs-border-color,#ced4da);border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-sampling-intro{max-width:50rem}.ve-sampling-controls{display:flex;align-items:end;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin:1rem 0}.ve-rate-fieldset{border:0;padding:0;margin:0;min-width:0}.ve-rate-fieldset legend{font-size:.85rem;font-weight:700;margin-bottom:.4rem}.ve-button-row{display:flex;gap:.5rem;flex-wrap:wrap}.ve-sampling-button{border:1px solid var(--bs-border-color,#6c757d);border-radius:.35rem;padding:.55rem .85rem;font-weight:600;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-sampling-button[aria-pressed=true],.ve-sampling-button.ve-primary{border-color:#1464b5;background:#1464b5;color:#fff}.quarto-dark .ve-sampling-button[aria-pressed=true],.quarto-dark .ve-sampling-button.ve-primary{border-color:#73b7ff;background:#73b7ff;color:#10212b}.ve-sampling-button:focus-visible{outline:3px solid color-mix(in srgb,var(--ve-accent) 45%,transparent);outline-offset:2px}.ve-sampling-progress{width:100%;height:.55rem;accent-color:var(--ve-accent)}.ve-sampling-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1rem;margin-top:1rem}.ve-sample-panel{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.5rem;padding:clamp(.65rem,2vw,1rem);margin:0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.ve-sample-panel h4{font-size:1rem;margin:0 0 .25rem}.ve-sample-panel svg{display:block;width:100%;height:auto}.ve-sample-stat{font-variant-numeric:tabular-nums;margin:.2rem 0 .65rem}.ve-sample-note{font-size:.85rem;color:var(--ve-muted);margin:.5rem 0 0}.ve-empty-sample{display:grid;place-items:center;min-height:13rem;border:1px dashed var(--bs-border-color,#adb5bd);border-radius:.35rem;color:var(--ve-muted);text-align:center;padding:1rem}.ve-sampling-status{font-variant-numeric:tabular-nums;margin:.4rem 0}.ve-dot{fill:var(--ve-accent);fill-opacity:.72}.ve-dot-latest{fill:var(--ve-warm);stroke:var(--bs-body-bg,#fff);stroke-width:1.5}.ve-sample-axis{stroke:currentColor;stroke-opacity:.45}.ve-sample-guide{stroke:currentColor;stroke-opacity:.1}.ve-latest-line{stroke:var(--ve-accent);stroke-width:5;stroke-linecap:round}.ve-latest-dot{fill:var(--ve-warm);stroke:var(--bs-body-bg,#fff);stroke-width:2}.ve-draw-breakdown{width:100%;border-collapse:collapse;font-size:.82rem;font-variant-numeric:tabular-nums;margin-top:.75rem}.ve-draw-breakdown th,.ve-draw-breakdown td{padding:.35rem .45rem;border-bottom:1px solid var(--bs-border-color,#dee2e6);text-align:right;white-space:nowrap}.ve-draw-breakdown th:first-child{text-align:left}.ve-draw-breakdown-wrap{max-width:100%;overflow-x:auto}@media(max-width:575px){.ve-sampling-controls{align-items:stretch}.ve-sampling-controls>.ve-button-row{width:100%}.ve-sampling-controls>.ve-button-row .ve-sampling-button{flex:1}.ve-sampling-button{padding:.55rem .7rem}}"])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -469,17 +694,16 @@ worked-analytic-mean
                                   (posterior-predictive-stratum rng stratum))
                                 worked-strata))))))
 
+^:kindly/hide-code
 (def worked-simulation-summary
   {:draws simulation-draws
    :mean (double (/ (reduce + worked-simulation) simulation-draws))
    :equal-tail-95 (equal-tail-quantiles worked-simulation)})
 
-worked-simulation-summary
-
 ;; Small differences are Monte Carlo error. The verification tolerance used for
 ;; this draft is ±20 pairs for the mean and ±40 pairs for each endpoint.
 ;;
-;; ## When should the test stop?
+;; ## 7. Decide: when should the test stop?
 ;;
 ;; The stopping rule is also provisional:
 ;;
@@ -488,7 +712,16 @@ worked-simulation-summary
 ;; - target a 95% interval half-width near 10% of the pool;
 ;; - use 96 items as a soft maximum;
 ;; - always allow the learner to stop voluntarily.
+;;
+;; The **minimum length** prevents an unstable early estimate from triggering a
+;; precision rule. **Round boundaries** preserve the same number of sampled
+;; items per stratum. The **precision target** asks whether the interval's
+;; half-width is at most 10% of the pool. The **soft maximum** recommends
+;; stopping at 96 without making continued participation impossible. A
+;; **voluntary stop** overrides all statistical criteria because the learner
+;; remains in control.
 
+^:kindly/hide-code
 (defn stopping-check
   "Evaluate the provisional rule at an eight-item round boundary."
   [{:keys [items-tested interval pool-size voluntary?]
@@ -505,6 +738,16 @@ worked-simulation-summary
      :target? target?
      :soft-max? soft-max?
      :stop? (or voluntary? target? soft-max?)}))
+
+^:kindly/hide-code
+(math/code-detail
+ "code-stopping-decision"
+ "Applying the v1 stopping decision"
+ [:div
+  [:p "Assessment occurs only at complete eight-item rounds and only after the 32-item minimum. The precision target and soft maximum are separate reasons to recommend stopping."]
+  [:pre [:code "(let [complete-round? (zero? (mod items-tested 8))\n      assess? (and complete-round?\n                   (>= items-tested 32))\n      half-width (/ (- upper lower) 2.0)\n      target? (and assess?\n                   (<= half-width (* 0.10 pool-size)))\n      soft-max? (and assess?\n                     (>= items-tested 96))]\n  {:stop? (or voluntary? target? soft-max?)})"]]
+  [:p "The complete function also returns each intermediate condition, making the final recommendation explainable and testable."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the stopping predicate and examples"]]])
 
 ^:kindly/hide-code
 (def stopping-examples
@@ -539,6 +782,101 @@ worked-simulation-summary
 ;; At 36 items the interval happens to be narrow enough, but the function does
 ;; not assess it: 36 is not the end of an eight-item round. At 96, the soft
 ;; maximum recommends stopping even when the width target is missed.
+
+;; ### Explore the rule without rewriting history
+;;
+;; The controls below begin at the authoritative v1 defaults: minimum 32,
+;; interval half-width target 10% of the pool, and soft cap 96. Changing those
+;; three values creates a **counterfactual teaching scenario** only. It does not
+;; alter this article's recorded model, examples, assertions, or scorer.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.ve-simulator
+  [:div#stopping-rule-explorer
+   [:p "Loading the teaching-only stopping-rule explorer…"]]
+  [:noscript "This explorer needs JavaScript. The authoritative v1 defaults and stopping table above remain available."]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:span.article-marker "Build / Check / Decide"]
+  [:p "Build: compute the exact finite-pool distribution and a qualified estimate. Check: reproduce it with a seeded simulation and inspect stopping only at round boundaries. Decide: stop for voluntary choice, adequate precision after the minimum, or the soft maximum—without changing the rule after seeing one learner's result."]])
+;;
+;; ## 8. Reproduce: keep the model separate from the machinery
+;;
+;; A trustworthy calculation needs a boundary between the mathematical model
+;; and software that reads files, draws charts, or responds to clicks. A **pure
+;; function** returns an output determined only by its inputs. A **side effect**
+;; changes or observes something outside that return value, such as a database,
+;; clock, random generator, file, or browser state. The scorer's mathematics
+;; should remain pure; storage, UI, clocks, and unseeded randomness belong at the
+;; boundary. Clojure encourages this separation without pretending all useful
+;; programs are side-effect-free.
+;;
+;; The worked example is also a **fixture**: a small, named input with expected
+;; outputs used repeatedly in checks. An **immutable version** is never edited
+;; after events refer to it; a changed pool or item receives a new identifier.
+;; The original `correct`, `wrong`, and `dont-know` events remain unchanged so a
+;; later algorithm can replay them. A **seed** turns pseudo-random prediction
+;; into a repeatable function of versioned inputs.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:dl.ve-definition-grid
+  [:div.ve-definition [:dt "Parity test"] [:dd "The same fixture is scored in Clojure on the JVM and ClojureScript in the browser; both implementations must agree on the protected behavior."]]
+  [:div.ve-definition [:dt "Build"] [:dd "Transform source and dependencies into artifacts that another tool can execute or publish."]]
+  [:div.ve-definition [:dt "Render"] [:dd "Evaluate the executable article and turn its structured source into the final page readers see."]]
+  [:div.ve-definition [:dt "CI"] [:dd "Continuous integration: automated builds and tests run on repository changes rather than relying only on one workstation."]]
+  [:div.ve-definition [:dt "Release gate"] [:dd "A required check that must pass before publication; here the final gate includes a full-site render."]]])
+
+^:kindly/hide-code
+(kind/mermaid
+ "flowchart LR
+    E[Estimand] --> V[Versioned pool<br/>and raw events]
+    V --> P[Pure scorer]
+    P --> S[Seeded prediction]
+    S --> T[CLJ and CLJS<br/>parity tests]
+    T --> R[Rendered article]
+    R --> B[Browser checks]
+    B --> G[Publication gate]")
+
+^:kindly/hide-code
+(kind/hiccup
+ [:p.ve-workflow-caption
+  "Model/software workflow. Every arrow carries explicit, versioned evidence forward; a later presentation layer does not redefine the estimand or scorer."])
+
+^:kindly/hide-code
+(def worked-fixture
+  {:fixture-version "beta-binomial-v1-worked-2026-07-12"
+   :algorithm-version "beta-binomial-v1"
+   :pool-id "pedagogical-8000-v1"
+   :seed 20260712
+   :strata worked-strata})
+
+^:kindly/hide-code
+(defn score-worked-fixture
+  "Deterministic scoring shell for the versioned pedagogical fixture."
+  [{:keys [seed strata]}]
+  {:analytic-mean (long (reduce + (map analytic-stratum-mean strata)))
+   :one-seeded-draw (posterior-predictive-total seed strata)})
+
+^:kindly/hide-code
+(math/code-detail
+ "code-pure-boundary-fixture"
+ "Keeping a pure scoring boundary and deterministic fixture"
+ [:div
+  [:p "All changing inputs are explicit data. The function creates its seeded generator internally, returns a value, and neither reads nor writes application storage."]
+  [:pre [:code "(def worked-fixture\n  {:fixture-version \"beta-binomial-v1-worked-2026-07-12\"\n   :algorithm-version \"beta-binomial-v1\"\n   :pool-id \"pedagogical-8000-v1\"\n   :seed 20260712\n   :strata worked-strata})\n\n(defn score-worked-fixture [{:keys [seed strata]}]\n  {:analytic-mean\n   (long (reduce + (map analytic-stratum-mean strata)))\n   :one-seeded-draw\n   (posterior-predictive-total seed strata)})"]]
+  [:p "Calling this function twice with the same fixture must return equal maps; the final regression checks enforce that deterministic replay."]
+  [:p.article-code-source [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj"} "View the fixture, scorer, and assertions"]]])
+
+;; The article itself is a separate presentation path: Clay evaluates the
+;; Clojure source, writes QMD, Quarto renders HTML, and Scittle/Reagent supplies
+;; browser interactions. Browser checks cover accessible labels, both colour
+;; themes, responsive widths, control behavior, and console errors. **CI** can
+;; automate repeatable tests, but a passing software build is not evidence that
+;; a provisional measurement assumption is true.
 ;;
 ;; ## What this model postpones
 ;;
@@ -557,6 +895,12 @@ worked-simulation-summary
 ;; In particular, I am not using a naive independent-form formula as a final
 ;; lemma estimator. Forms of the same lemma are related, contexts vary in
 ;; informativeness, and a latent-variable model should express that structure.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:span.article-marker "Checkpoint"]
+  [:p "The v1 model now has a precise estimand, balanced non-adaptive sampling, lossless raw events, eight conjugate Beta updates, finite-pool posterior prediction, an exact qualified interval, seeded numerical checks, and an explicit stopping rule. Every modelling choice remains provisional. The next article tests one refinement—continuous pair frequency—without silently rewriting this checkpoint."]])
 ;;
 ;; ## Sources and further reading
 ;;
@@ -565,24 +909,36 @@ worked-simulation-summary
 ;; - [Apache Commons Math distribution API](https://commons.apache.org/proper/commons-math/javadocs/api-3.6.1/org/apache/commons/math3/distribution/package-summary.html), the distribution implementation underneath this Fastmath path.
 ;; - Council of Europe, [CEFR Companion Volume (2020)](https://rm.coe.int/cefr-companion-volume-with-new-descriptors-2020/16809ea0d4), for the broader language-proficiency framework; it does not define this pair-count estimand.
 ;; - Brysbaert & New, [SUBTLEX-US frequency norms](https://doi.org/10.3758/BRM.41.4.977), for evidence that contextual word frequency can be useful; this does not make frequency rank a calibrated item-difficulty scale.
+;; - [Clojure's functional-programming overview](https://clojure.org/about/functional_programming), for immutable data and the functional-core/side-effect boundary described here.
+;; - [Clay documentation](https://scicloj.github.io/clay/), [Quarto HTML documentation](https://quarto.org/docs/output-formats/html-basics.html), and the [Scittle repository](https://github.com/babashka/scittle), for the article build and browser runtime.
+;; - [GitHub Actions documentation](https://docs.github.com/en/actions/get-started/understand-github-actions), for the CI terminology.
 ;;
 ;; This is a learning-in-public checkpoint. Follow-up posts will replace the
 ;; roughest assumptions one at a time, beginning with continuous frequency.
 
 ^:kindly/hide-code
-(do
-  (assert (= {:alpha 5.0 :beta 1.0} (posterior-parameters 4 4)))
-  (assert (= 0 (collapse-response :wrong)
-             (collapse-response :dont-know)))
-  (assert (not= :wrong :dont-know))
-  (assert (= 4334 worked-analytic-mean))
-  (assert (every? #(not (:assess? (stopping-check
-                                   {:items-tested %
-                                    :interval [0 8000]
-                                    :pool-size 8000})))
-                  [33 34 35 36 37 38 39]))
-  (assert (< (Math/abs (- (:mean worked-simulation-summary) 4334.0)) 20.0))
-  (let [{:keys [lower upper]} (:equal-tail-95 worked-simulation-summary)]
-    (assert (< (Math/abs (- lower 3404)) 40))
-    (assert (< (Math/abs (- upper 5249)) 40)))
-  :verified)
+(def regression-status
+  (do
+    (assert (= {:alpha 5.0 :beta 1.0} (posterior-parameters 4 4)))
+    (assert (= 0 (collapse-response :wrong)
+               (collapse-response :dont-know)))
+    (assert (not= :wrong :dont-know))
+    (assert (= 4334 worked-analytic-mean))
+    (assert (every? #(not (:assess? (stopping-check
+                                     {:items-tested %
+                                      :interval [0 8000]
+                                      :pool-size 8000})))
+                    [33 34 35 36 37 38 39]))
+    (assert (< (Math/abs (- (:mean worked-simulation-summary) 4334.0)) 20.0))
+    (let [{:keys [lower upper]} (:equal-tail-95 worked-simulation-summary)]
+      (assert (< (Math/abs (- lower 3404)) 40))
+      (assert (< (Math/abs (- upper 5249)) 40)))
+    (assert (= (score-worked-fixture worked-fixture)
+               (score-worked-fixture worked-fixture)))
+    :verified))
+
+^:kindly/hide-code
+(kind/hiccup
+ [:p.article-recap
+  [:span.article-marker "Regression check"]
+  " All executable assertions passed, including the preserved 4,334 mean, Monte Carlo tolerance around the exact 3,404–5,249 interval, round-boundary behavior, and deterministic fixture replay."])

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass.clj
@@ -56,7 +56,7 @@
 ^:kindly/hide-code
 (kind/hiccup
  [:style
-  ".series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#4f5b66}.quarto-dark .series-status{color:#b9c7d2}"])
+  ".series-toc{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:0 0 1.4rem;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem .45rem}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--ve-muted)}.series-current{margin:.35rem 0 .35rem -.7rem;border-left:4px solid var(--ve-accent);border-radius:.4rem;padding:.6rem .75rem!important;background:color-mix(in srgb,var(--bs-body-bg,#fff) 84%,var(--ve-accent) 16%);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--ve-accent) 35%,transparent);font-weight:700}.series-current>a{color:var(--ve-accent)}.series-current .series-status{border-radius:999px;padding:.18rem .48rem;background:var(--ve-accent);color:#fff}.quarto-dark .series-current .series-status{color:#10212b}"])
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -67,12 +67,13 @@
    [:li [:a {:href "bayes_theorem_simulations.html"}
          "Bayes' theorem from uncertainty to decision"]
     [:span.series-status "published"]]
-   [:li [:a {:href "beta_binomial_first_pass.html"}
-         "Estimating vocabulary size: a stratified Beta–binomial first pass"]
+   [:li.series-current [:a {:href "beta_binomial_first_pass.html"
+                            :aria-current "page"}
+                        "Estimating vocabulary size: a stratified Beta–binomial first pass"]
     [:span.series-status "you are here"]]
    [:li [:a {:href "pair_frequency_logistic_v2_article.html"}
          "Does pair frequency predict learner responses?"]
-    [:span.series-status "next"]]
+    [:span.series-status "published"]]
    [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
     [:span.series-status "planned"]]
    [:li "From Correlated Form Pairs to Latent Lemma Knowledge"

--- a/src/language_learning/vocabulary_estimation/beta_binomial_first_pass_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/beta_binomial_first_pass_interactive.cljs
@@ -43,6 +43,7 @@
   [response p]
   (case response
     :correct p
+    :wrong (- 1 p)
     :dont-know (- 1 p)
     1))
 
@@ -62,6 +63,7 @@
 (defn response-label [response]
   (case response
     :correct "correct"
+    :wrong "wrong"
     :dont-know "don't know"
     "none yet"))
 
@@ -69,19 +71,19 @@
   [{:keys [alpha beta previous last-response]}]
   (let [[previous-alpha previous-beta] previous
         curves [{:label "Prior Beta(1,1)"
-                 :color "#6c757d"
+                 :color "var(--ve-muted)"
                  :dash "6 5"
                  :f #(beta-density 1 1 %)}
                 {:label (str "Previous Beta(" previous-alpha "," previous-beta ")")
-                 :color "#7b61a8"
+                 :color "var(--ve-purple)"
                  :dash "3 4"
                  :f #(beta-density previous-alpha previous-beta %)}
                 {:label (str "Last-response likelihood (" (response-label last-response) ")")
-                 :color "#e69f00"
+                 :color "var(--ve-warm)"
                  :dash "8 4"
                  :f #(likelihood last-response %)}
                 {:label (str "Current Beta(" alpha "," beta ")")
-                 :color "#2780e3"
+                 :color "var(--ve-accent)"
                  :dash nil
                  :f #(beta-density alpha beta %)}]
         max-y (apply max 1 (mapcat (fn [{:keys [f]}] (map f plot-points)) curves))]
@@ -111,7 +113,7 @@
        [:path {:d (scaled-path f max-y)
                :fill "none"
                :stroke color
-               :stroke-width (if (= color "#2780e3") 4 2.5)
+               :stroke-width (if (= color "var(--ve-accent)") 4 2.5)
                :stroke-dasharray dash
                :vector-effect "non-scaling-stroke"}])
      (for [[i {:keys [label color dash]}] (map-indexed vector curves)
@@ -144,6 +146,73 @@
                     :background "var(--bs-body-bg, white)"
                     :color "var(--bs-body-color, #212529)"}}
    label])
+
+(def balanced-response-sequence
+  [:correct :wrong :dont-know :correct :correct :dont-know :wrong :correct
+   :dont-know :correct :wrong :wrong :correct :dont-know :correct :correct])
+
+(def balanced-selection-limit 16)
+(defonce balanced-state (r/atom {:revealed 0}))
+
+(defn scheduled-selection [index]
+  (let [stratum (inc (mod index 8))
+        round (inc (quot index 8))]
+    {:stratum stratum
+     :round round
+     :item-id (str "S" stratum "-R" round)
+     :response (nth balanced-response-sequence index)}))
+
+(defn reveal-next-selection! []
+  (swap! balanced-state update :revealed
+         #(min balanced-selection-limit (inc %))))
+
+(defn reset-balanced-rounds! []
+  (reset! balanced-state {:revealed 0}))
+
+(defn balanced-round-simulator []
+  (let [revealed (:revealed @balanced-state)
+        selections (mapv scheduled-selection (range revealed))
+        latest (peek selections)
+        complete? (= revealed balanced-selection-limit)]
+    [:section.ve-round-shell {:aria-labelledby "balanced-round-heading"}
+     [:h3#balanced-round-heading "Balanced non-adaptive rounds"]
+     [:p
+      "Two fixed demonstration rounds are queued. Each click reveals the next scheduled item and its sample response."]
+     [:div.ve-round-grid
+      (for [stratum (range 1 9)
+            :let [seen (filterv #(= stratum (:stratum %)) selections)
+                  most-recent (peek seen)
+                  next-round (inc (count seen))]]
+        ^{:key stratum}
+        [:div.ve-round-card
+         [:strong (str "Stratum " stratum)]
+         [:span (if most-recent
+                  (str "Latest: " (:item-id most-recent)
+                       " · " (response-label (:response most-recent)))
+                  "Latest: none")]
+         [:small (if (< next-round 3)
+                   (str "Next queued: S" stratum "-R" next-round)
+                   "Two demonstration items used")]])]
+     [:progress.ve-round-progress
+      {:value revealed :max balanced-selection-limit
+       :aria-label "Scheduled demonstration items revealed"}]
+     [:p.ve-round-status
+      {:aria-live "polite"}
+      (cond
+        complete? "Two complete rounds: every stratum supplied two unseen items."
+        latest (str "Revealed " (:item-id latest) " as "
+                    (response-label (:response latest))
+                    ". The response did not alter any next-item queue.")
+        :else "Ready. No response has altered the fixed queues.")]
+     [:div.ve-button-row
+      [:button.ve-sampling-button.ve-primary
+       {:type "button" :on-click reveal-next-selection! :disabled complete?}
+       (if complete? "Two rounds complete" "Reveal next scheduled item")]
+      [:button.ve-sampling-button
+       {:type "button" :on-click reset-balanced-rounds!}
+       "Reset"]]
+     [:p.ve-sample-note
+      "The response labels are illustrative. Schedule order is S1 through S8 in every round, independent of all answers."]]))
 
 (defn make-rng [seed]
   #js {:state (mod seed 2147483647)})
@@ -183,10 +252,16 @@
     (sample-low-p-binomial! rng trials p)))
 
 (defn sample-stratum! [rng {:keys [pool-size k n alpha beta] :as stratum}]
-  (let [p (sample-integer-beta! rng alpha beta)]
+  (let [p (sample-integer-beta! rng alpha beta)
+        untested (- pool-size n)
+        predicted-untested (sample-binomial! rng untested p)]
     (assoc stratum
            :p p
-           :known (+ k (sample-binomial! rng (- pool-size n) p)))))
+           :tested-correct k
+           :tested-not-correct (- n k)
+           :untested untested
+           :predicted-untested predicted-untested
+           :known (+ k predicted-untested))))
 
 (defn sample-complete-draw! [rng]
   (let [strata (mapv #(sample-stratum! rng %) worked-sampling-strata)]
@@ -331,8 +406,29 @@
            (str (format-rate p) " → " known)]])
        [:text {:x 382 :y 350 :text-anchor "middle" :font-size 13 :fill "currentColor"}
         "Known pairs in each 1,000-pair stratum"]]
+      [:div.ve-draw-breakdown-wrap
+       [:table.ve-draw-breakdown
+        [:caption.ve-sr-only
+         "Newest posterior-predictive draw split into tested correct, tested not-correct, predicted untested, and total known pairs"]
+        [:thead
+         [:tr
+          [:th {:scope "col"} "Stratum"]
+          [:th {:scope "col"} "Tested correct"]
+          [:th {:scope "col"} "Tested not-correct"]
+          [:th {:scope "col"} "Predicted untested"]
+          [:th {:scope "col"} "Known total"]]]
+        [:tbody
+         (for [{:keys [index tested-correct tested-not-correct
+                       predicted-untested known]} (:strata latest)]
+           ^{:key index}
+           [:tr
+            [:th {:scope "row"} (str "S" index)]
+            [:td tested-correct]
+            [:td tested-not-correct]
+            [:td predicted-untested]
+            [:td known]])]]]
       [:figcaption.ve-sample-note
-       "Each row shows p drawn from that stratum's Beta posterior, then the resulting finite-pool known count (observed correct + simulated untested known)."]]
+       "Tested-correct pairs are added once. Tested-not-correct pairs remain zero. Only the 996 untested pairs receive a predictive draw."]]
      [:div.ve-empty-sample
       "Press Start to reveal each complete eight-stratum draw."])])
 
@@ -449,6 +545,109 @@
       [latest-draw-chart latest draw-count]
       [all-draws-chart draws]]]))
 
+(def authoritative-stopping-settings
+  {:minimum 32
+   :target-percent 10
+   :soft-cap 96})
+
+(def initial-stopping-state
+  (merge authoritative-stopping-settings
+         {:items-tested 40
+          :half-width 750}))
+
+(defonce stopping-state (r/atom initial-stopping-state))
+
+(defn event-number [event]
+  (js/Number (.. event -target -value)))
+
+(defn update-stopping-setting! [key event]
+  (swap! stopping-state assoc key (event-number event)))
+
+(defn reset-stopping-settings! []
+  (reset! stopping-state initial-stopping-state))
+
+(defn explorer-stopping-check
+  [{:keys [minimum target-percent soft-cap items-tested half-width]}]
+  (let [complete-round? (zero? (mod items-tested 8))
+        assess? (and complete-round? (>= items-tested minimum))
+        target-count (* (/ target-percent 100.0) 8000)
+        target? (and assess? (<= half-width target-count))
+        soft-max? (and assess? (>= items-tested soft-cap))]
+    {:complete-round? complete-round?
+     :assess? assess?
+     :target-count target-count
+     :target? target?
+     :soft-max? soft-max?
+     :stop? (or target? soft-max?)}))
+
+(defn stopping-range
+  [{:keys [id label value min max step suffix on-change]}]
+  [:div.ve-stop-field
+   [:div
+    [:label {:for id} label]
+    [:output {:for id} (str value suffix)]]
+   [:input {:id id :type "range" :value value :min min :max max :step step
+            :on-input on-change
+            :on-change on-change}]])
+
+(defn stopping-rule-explorer []
+  (let [{:keys [minimum target-percent soft-cap items-tested half-width]
+         :as settings} @stopping-state
+        {:keys [complete-round? assess? target-count target? soft-max? stop?]}
+        (explorer-stopping-check settings)
+        observed-percent (* 100.0 (/ half-width 8000))
+        defaults? (= authoritative-stopping-settings
+                     (select-keys settings [:minimum :target-percent :soft-cap]))
+        decision (cond
+                   (not complete-round?) "Not assessed: this is not an eight-item round boundary."
+                   (< items-tested minimum) "Not assessed: the selected minimum has not been reached."
+                   (and target? soft-max?) "Recommend stop: both precision target and soft cap are met."
+                   target? "Recommend stop: the precision target is met."
+                   soft-max? "Recommend stop: the soft cap is reached."
+                   :else "Continue: assessed, but neither stopping condition is met.")]
+    [:section.ve-stop-shell {:aria-labelledby "stopping-explorer-heading"}
+     [:h3#stopping-explorer-heading "Teaching-only stopping-rule explorer"]
+     [:div {:class (str "ve-stop-banner "
+                        (if defaults? "is-default" "is-counterfactual"))}
+      [:strong (if defaults?
+                 "Authoritative v1 defaults"
+                 "Counterfactual teaching settings")]
+      [:span (if defaults?
+               " Minimum 32 · target 10% · soft cap 96."
+               " These controls do not rewrite the article's v1 rule.")]]
+     [:div.ve-stop-grid
+      [stopping-range {:id "stop-minimum" :label "Minimum items"
+                       :value minimum :min 8 :max 64 :step 8 :suffix ""
+                       :on-change #(update-stopping-setting! :minimum %)}]
+      [stopping-range {:id "stop-target" :label "Interval half-width target"
+                       :value target-percent :min 5 :max 25 :step 1 :suffix "% of pool"
+                       :on-change #(update-stopping-setting! :target-percent %)}]
+      [stopping-range {:id "stop-cap" :label "Soft cap"
+                       :value soft-cap :min 64 :max 160 :step 8 :suffix " items"
+                       :on-change #(update-stopping-setting! :soft-cap %)}]
+      [stopping-range {:id "stop-items" :label "Observed items"
+                       :value items-tested :min 8 :max 160 :step 4 :suffix ""
+                       :on-change #(update-stopping-setting! :items-tested %)}]
+      [stopping-range {:id "stop-width" :label "Observed interval half-width"
+                       :value half-width :min 200 :max 2000 :step 50 :suffix " pairs"
+                       :on-change #(update-stopping-setting! :half-width %)}]]
+     [:div.ve-stop-result {:aria-live "polite"}
+      [:strong decision]
+      [:ul
+       [:li (str "Complete round: " (if complete-round? "yes" "no"))]
+       [:li (str "Eligible to assess: " (if assess? "yes" "no"))]
+       [:li (str "Precision threshold: ±" (js/Math.round target-count)
+                 " pairs (" target-percent "% of pool).")]
+       [:li (str "Observed precision: ±" half-width " pairs ("
+                 (.toFixed observed-percent 1) "% of pool).")]
+       [:li (str "Soft cap reached: " (if soft-max? "yes" "no"))]]]
+     [:div.ve-button-row
+      [:button.ve-sampling-button
+       {:type "button" :on-click reset-stopping-settings!}
+       "Reset v1 defaults"]]
+     [:p.ve-sample-note
+      "Voluntary stopping remains available in every scenario and is intentionally outside this statistical recommendation."]]))
+
 (defn simulator []
   (let [{:keys [alpha beta responses] :as current} @state
         n (count responses)
@@ -472,19 +671,24 @@
       "The Beta curves are normalized densities on one shared scale. The response likelihood uses its natural 0–1 scale; compare its shape, not its height, with the densities."]
      [:div {:style {:display "flex" :gap ".65rem" :flex-wrap "wrap" :margin-top "1rem"}}
       [control-button "Correct" #(record-response! :correct) "ve-correct"]
+      [control-button "Wrong" #(record-response! :wrong) "ve-wrong"]
       [control-button "Don't know" #(record-response! :dont-know) "ve-dont-know"]
       [control-button "Reset" #(reset! state initial-state) "ve-reset"]]
      [:p {:style {:font-size ".9rem"
                   :color "var(--bs-body-color, #212529)"
                   :opacity 0.75
                   :margin-bottom 0}}
-      "Keyboard: Tab to a button, then press Enter or Space. “Don't know” contributes the same stage-one likelihood as a wrong answer, while the raw value remains distinct."]]))
+      "Keyboard: Tab to a button, then press Enter or Space. Wrong and “don't know” contribute the same stage-one likelihood, while their raw values remain distinct."]]))
 
 (defn ^:export mount []
+  (when-let [root (js/document.getElementById "balanced-round-simulator")]
+    (rdom/render [balanced-round-simulator] root))
   (when-let [root (js/document.getElementById "beta-binomial-simulator")]
     (rdom/render [simulator] root))
   (when-let [root (js/document.getElementById "posterior-sampling-simulator")]
-    (rdom/render [posterior-sampling-simulator] root)))
+    (rdom/render [posterior-sampling-simulator] root))
+  (when-let [root (js/document.getElementById "stopping-rule-explorer")]
+    (rdom/render [stopping-rule-explorer] root)))
 
 (if (= "loading" js/document.readyState)
   (.addEventListener js/document "DOMContentLoaded" mount)

--- a/src/language_learning/vocabulary_estimation/math_explanations.clj
+++ b/src/language_learning/vocabulary_estimation/math_explanations.clj
@@ -5,14 +5,28 @@
   (kind/hiccup
    [:style
     (str
-     ".article-explanations-toolbar{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:.8rem;min-width:0;border:1px solid color-mix(in srgb,var(--bs-body-color,#212529) 22%,transparent);border-left:4px solid #2780e3;border-radius:.35rem;padding:.8rem 1rem;margin:1.25rem 0;background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 88%,#2780e3 12%);color:var(--bs-body-color,#212529)}"
+     ".article-explanations-toolbar{display:grid;grid-template-columns:minmax(0,1fr) auto auto;align-items:center;gap:.8rem;min-width:0;border:1px solid color-mix(in srgb,var(--bs-body-color,#212529) 22%,transparent);border-left:4px solid #2780e3;border-radius:.35rem;padding:.8rem 1rem;margin:1.25rem 0;background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 88%,#2780e3 12%);color:var(--bs-body-color,#212529)}"
      ".article-explanations-toolbar p{min-width:0;margin:0;overflow-wrap:anywhere}"
      ".article-explanations-toolbar strong{color:inherit}"
-     ".article-explanations-toggle{border:1px solid #2780e3;border-radius:.35rem;padding:.5rem .8rem;font-weight:700;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
-     ".article-explanations-toggle[aria-pressed=true]{background:#1464b5;color:#fff}"
-     ".article-explanations-toggle:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 50%,transparent);outline-offset:3px}"
-     ".article-help-icon:focus-visible,.article-explanation summary:focus-visible{outline:3px solid color-mix(in srgb,var(--explanation-accent,#2780e3) 55%,transparent);outline-offset:3px}"
-     ".article-explanations-description,.article-explanations-status{display:block;margin-top:.2rem;font-size:.84rem;color:#3f4b55}"
+     ".article-explanations-toggle,.article-code-toggle{border:1px solid #2780e3;border-radius:.35rem;padding:.5rem .8rem;font-weight:700;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}"
+     ".article-explanations-toggle[aria-pressed=true],.article-code-toggle[aria-pressed=true]{background:#1464b5;color:#fff}"
+     ".article-explanations-toggle:focus-visible,.article-code-toggle:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 50%,transparent);outline-offset:3px}"
+     ".article-help-icon:focus-visible,.article-explanation summary:focus-visible,.article-code-detail summary:focus-visible{outline:3px solid color-mix(in srgb,var(--explanation-accent,#2780e3) 55%,transparent);outline-offset:3px}"
+     ".article-explanations-description,.article-explanations-status,.article-code-status{display:block;margin-top:.2rem;font-size:.84rem;color:#3f4b55}"
+     ".article-reading-action{display:grid;gap:.2rem;min-width:min(100%,12rem)}"
+     ".article-code-detail{min-width:0;margin:1rem 0;border:1px solid color-mix(in srgb,#6f42c1 45%,var(--bs-border-color,#dee2e6));border-radius:.55rem;background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 94%,#6f42c1 6%);color:var(--bs-body-color,#212529)}"
+     "details.article-code-detail>summary{padding:.72rem .85rem;font-weight:750;cursor:pointer;color:var(--bs-body-color,#212529)!important;overflow-wrap:anywhere}"
+     ".article-code-detail[open] summary{border-bottom:1px solid color-mix(in srgb,#6f42c1 35%,transparent)}"
+     ".article-code-detail-body{min-width:0;padding:.8rem .9rem 1rem}"
+     ".article-code-detail-body>*:first-child{margin-top:0}.article-code-detail-body>*:last-child{margin-bottom:0}"
+     ".article-code-detail pre{max-width:100%;overflow:auto;margin:.75rem 0;padding:.75rem;border-radius:.4rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 84%,var(--bs-body-color,#212529) 16%)}"
+     ".article-code-detail code{white-space:pre-wrap;overflow-wrap:anywhere}"
+     ".article-code-source{font-size:.86rem}"
+     ".article-chapter-map{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,11rem),1fr));gap:.65rem;margin:1.25rem 0;padding:0;list-style:none;counter-reset:chapter-map}"
+     ".article-chapter-map li{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.5rem;padding:.75rem;background:var(--bs-body-bg,#fff);overflow-wrap:anywhere;counter-increment:chapter-map}"
+     ".article-chapter-map li::before{content:counter(chapter-map);display:grid;place-items:center;width:1.6rem;height:1.6rem;margin-bottom:.45rem;border-radius:50%;background:#1464b5;color:#fff;font-weight:800}"
+     ".article-marker{display:inline-block;margin:.2rem .35rem .2rem 0;border-radius:999px;padding:.18rem .58rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 82%,#2780e3 18%);color:var(--bs-body-color,#212529);font-size:.78rem;font-weight:800;letter-spacing:.03em;text-transform:uppercase}"
+     ".article-recap{min-width:0;border:1px solid color-mix(in srgb,#0f695f 45%,var(--bs-border-color,#dee2e6));border-left:4px solid #0f695f;border-radius:.5rem;padding:1rem 1.1rem;margin:1.35rem 0;background:var(--bs-body-bg,#fff);background:color-mix(in srgb,var(--bs-body-bg,#fff) 91%,#0f695f 9%);color:var(--bs-body-color,#212529)}"
      ".article-explanation-layout,.article-explanation-anchor,.article-explanation-slot{min-width:0}"
      ".article-explanation-layout{margin:0 0 .35rem}"
      ".article-help-icon{--explanation-accent:#155f9f;display:inline-grid;place-items:center;width:1.2rem;height:1.2rem;margin-left:.25rem;padding:0;border:1px solid var(--explanation-accent);border-radius:50%;background:var(--bs-body-bg,#fff);color:var(--explanation-accent);font:800 .75rem/1 system-ui,sans-serif;vertical-align:.14em;cursor:pointer}"
@@ -47,7 +61,7 @@
      ".quarto-dark .article-help-icon.accent-4,.quarto-dark .article-explanation.accent-4{--explanation-accent:#40c9b7}"
      ".quarto-dark .article-help-icon.accent-5,.quarto-dark .article-explanation.accent-5{--explanation-accent:#ff8fbd}"
      ".quarto-dark .article-help-icon.accent-6,.quarto-dark .article-explanation.accent-6{--explanation-accent:#e2cf5b}"
-     ".quarto-dark .article-explanations-description,.quarto-dark .article-explanations-status{color:#b9c7d2}"
+     ".quarto-dark .article-explanations-description,.quarto-dark .article-explanations-status,.quarto-dark .article-code-status{color:#b9c7d2}"
      ".quarto-dark .article-help-icon[aria-expanded=true]{color:#10212b}"
      "#quarto-document-content{transition:transform .2s ease}"
      "@media(min-width:1280px){"
@@ -61,7 +75,7 @@
      ".equation-help-anchor>.equation-help-icon{position:absolute;left:calc(100% + .15rem);top:50%;z-index:3;margin:0;transform:translateY(-50%)}"
      "}"
      "@media(max-width:1279px){.article-explanation-slot.has-open{margin:.55rem 0 1.25rem}.equation-help-icon{display:grid;margin:.35rem auto 0}}"
-     "@media(max-width:767px){.article-explanations-toolbar{grid-template-columns:minmax(0,1fr);align-items:stretch}.article-explanations-toggle{width:100%}}")]))
+     "@media(max-width:767px){.article-explanations-toolbar{grid-template-columns:minmax(0,1fr);align-items:stretch}.article-explanations-toggle,.article-code-toggle{width:100%}.article-reading-action{width:100%}}")]))
 
 (def ^:private explanation-controls-script
   "(() => {
@@ -73,6 +87,10 @@
     const marginQuery = window.matchMedia('(min-width: 1280px)');
     const mathRegistries = Array.from(document.querySelectorAll('.math-explanation-registry'));
     const termRegistries = Array.from(document.querySelectorAll('.term-explanation-registry'));
+    const codeDetails = Array.from(document.querySelectorAll('details.article-code-detail'));
+    const codeAction = document.getElementById('article-code-action');
+    const codeButton = document.getElementById('article-code-toggle');
+    const codeStatus = document.getElementById('article-code-status');
 
     const makeHelpButton = ({label, controls, classes = []}) => {
       const help = document.createElement('button');
@@ -109,8 +127,12 @@
     const precedingEquation = (registry) => {
       let cursor = registry;
       for (let depth = 0; cursor && cursor.parentElement && depth < 4; depth += 1) {
-        const candidate = cursor.previousElementSibling;
-        if (containsDisplayEquation(candidate)) return candidate;
+        let candidate = cursor.previousElementSibling;
+        while (candidate) {
+          if (containsDisplayEquation(candidate)) return candidate;
+          candidate = candidate.previousElementSibling;
+        }
+        if (cursor.parentElement.matches('section')) break;
         cursor = cursor.parentElement;
       }
       return null;
@@ -304,7 +326,7 @@
       if (articleMain) articleMain.classList.toggle('article-explanations-open', openItems.length > 0);
       globalButton.setAttribute('aria-pressed', String(allOpen));
       globalButton.textContent = `${allOpen ? 'Hide' : 'Show'} all help`;
-      if (heading) heading.textContent = 'Optional explanations';
+      if (heading) heading.textContent = 'Reading controls';
       const bothKinds = mathExplanations.length > 0 && terminologyExplanations.length > 0;
       const countParts = [];
       const progressParts = [];
@@ -317,17 +339,29 @@
         progressParts.push(`${openTerms} of ${terminologyExplanations.length} terminology item${terminologyExplanations.length === 1 ? '' : 's'}`);
       }
       if (description) {
-        description.textContent = bothKinds
-          ? 'Use the ? beside a term or equation. An equation icon can reveal several related definitions.'
+        const helpInstruction = bothKinds
+          ? 'Use the ? beside a term or equation for optional explanations.'
           : mathExplanations.length > 0
-            ? 'Use the ? beside an equation to reveal its related definitions.'
-            : 'Use the ? beside a term to reveal its definition.';
+            ? 'Use the ? beside an equation for optional explanations.'
+            : 'Use the ? beside a term for an optional definition.';
+        description.textContent = codeDetails.length > 0
+          ? `${helpInstruction} Code details remain inline and independent.`
+          : helpInstruction;
       }
       if (status) {
         status.textContent = openItems.length === 0
           ? `${countParts.join(' and ')} ${explanations.length === 1 ? 'is' : 'are'} hidden.`
           : `${progressParts.join(' and ')} shown.`;
       }
+
+      const openCodeCount = codeDetails.filter((item) => item.open).length;
+      const allCodeOpen = codeDetails.length > 0 && openCodeCount === codeDetails.length;
+      if (codeAction) codeAction.hidden = codeDetails.length === 0;
+      if (codeButton) {
+        codeButton.setAttribute('aria-pressed', String(allCodeOpen));
+        codeButton.textContent = allCodeOpen ? 'Hide all code details' : 'Show all code details';
+      }
+      if (codeStatus) codeStatus.textContent = `${openCodeCount}/${codeDetails.length} code details open.`;
     };
 
     globalButton.addEventListener('click', () => {
@@ -336,6 +370,13 @@
       sync();
       schedulePlacement();
     });
+    if (codeButton) {
+      codeButton.addEventListener('click', () => {
+        const shouldOpen = !codeDetails.every((item) => item.open);
+        codeDetails.forEach((item) => setOpen(item, shouldOpen));
+        sync();
+      });
+    }
     railHideAll.addEventListener('click', () => {
       explanations.forEach((item) => setOpen(item, false));
       sync();
@@ -364,6 +405,7 @@
         schedulePlacement();
       });
     });
+    codeDetails.forEach((item) => item.addEventListener('toggle', sync));
     marginQuery.addEventListener('change', () => {
       arrangeForViewport();
       sync();
@@ -392,20 +434,49 @@
    [:div.article-explanations-toolbar
     {:role "region" :aria-labelledby "article-explanations-heading"}
     [:p
-     [:strong#article-explanations-heading "Optional explanations"]
+     [:strong#article-explanations-heading "Reading controls"]
      [:span.article-explanations-description
       {:id "article-explanations-description"}
-      "Use the ? beside a term or equation. An equation icon can reveal several related definitions."]
+      "Help explains symbols and terms. Code details show how the examples were built. These controls are independent."]
      [:span.article-explanations-status
       {:id "article-explanations-status" :aria-live "polite"}
       "All explanation items are hidden by default."]]
-    [:button.article-explanations-toggle
-     {:id "article-explanations-toggle"
-      :type "button"
-      :aria-pressed "false"
-      :aria-describedby "article-explanations-description article-explanations-status"}
-     "Show all help"]
+    [:div.article-reading-action
+     [:button.article-explanations-toggle
+      {:id "article-explanations-toggle"
+       :type "button"
+       :aria-pressed "false"
+       :aria-describedby "article-explanations-description article-explanations-status"}
+      "Show all help"]]
+    [:div.article-reading-action
+     {:id "article-code-action"}
+     [:button.article-code-toggle
+      {:id "article-code-toggle"
+       :type "button"
+       :aria-pressed "false"
+       :aria-describedby "article-explanations-description article-code-status"}
+      "Show all code details"]
+     [:span.article-code-status
+      {:id "article-code-status" :aria-live "polite"}
+      "0/0 code details open."]]
     [:script explanation-controls-script]]))
+
+(defn code-detail
+  "Render one closed, inline implementation detail with an independent native
+  disclosure control. Body is arbitrary Hiccup, so callers may mix prose,
+  preformatted code, and a source link."
+  [id purpose body]
+  (let [summary-id (str id "--summary")
+        body-id (str id "--body")]
+    (kind/hiccup
+     [:details.article-code-detail
+      {:id id}
+      [:summary
+       {:id summary-id :aria-controls body-id}
+       (str "Code detail: " purpose)]
+      [:div.article-code-detail-body
+       {:id body-id :role "region" :aria-labelledby summary-id}
+       body]])))
 
 (defn- math-item
   [id term definition]

--- a/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_article.clj
+++ b/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_article.clj
@@ -20,7 +20,7 @@
 ^:kindly/hide-code
 (kind/hiccup
  [:style
-  ".pf-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.35rem 0;border-radius:.3rem}.pf-callout.fail{border-color:#c44536;background:#fff1ef}.pf-callout.provisional{border-color:#e69f00;background:#fff8e6}.pf-callout strong{display:block;margin-bottom:.3rem}.pf-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}.pf-card{min-width:0;border:1px solid #dee2e6;border-radius:.55rem;padding:1rem;background:var(--bs-body-bg,#fff)}.pf-card h3{font-size:1rem;margin:0 0 .4rem}.pf-card p{margin:.25rem 0}.pf-table-wrap{overflow-x:auto;margin:1.25rem 0}.pf-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}.pf-table th,.pf-table td{padding:.55rem .7rem;border-bottom:1px solid #dee2e6;text-align:right;white-space:nowrap}.pf-table th:first-child,.pf-table td:first-child{text-align:left}.pf-table thead th{border-bottom:2px solid #adb5bd}.pf-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.pf-code{overflow-wrap:anywhere}.pf-lab{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#4f5b66}.quarto-dark .series-status{color:#b9c7d2}@media(max-width:575px){.pf-table th,.pf-table td{padding:.45rem}.pf-card{padding:.8rem}}"])
+  ".pf-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.35rem 0;border-radius:.3rem}.pf-callout.fail{border-color:#c44536;background:#fff1ef}.pf-callout.provisional{border-color:#e69f00;background:#fff8e6}.pf-callout strong{display:block;margin-bottom:.3rem}.pf-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}.pf-card{min-width:0;border:1px solid #dee2e6;border-radius:.55rem;padding:1rem;background:var(--bs-body-bg,#fff)}.pf-card h3{font-size:1rem;margin:0 0 .4rem}.pf-card p{margin:.25rem 0}.pf-table-wrap{overflow-x:auto;margin:1.25rem 0}.pf-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}.pf-table th,.pf-table td{padding:.55rem .7rem;border-bottom:1px solid #dee2e6;text-align:right;white-space:nowrap}.pf-table th:first-child,.pf-table td:first-child{text-align:left}.pf-table thead th{border-bottom:2px solid #adb5bd}.pf-explain-table th,.pf-explain-table td{white-space:normal;text-align:left;vertical-align:top;min-width:9rem}.pf-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.pf-code{overflow-wrap:anywhere}.pf-lab{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#4f5b66}.quarto-dark .series-status{color:#b9c7d2}@media(max-width:575px){.pf-table th,.pf-table td{padding:.45rem}.pf-card{padding:.8rem}}"])
 
 ^:kindly/hide-code
 (math/styles)
@@ -90,7 +90,7 @@
 ;; The defensible claim is therefore modest: **frequency is a plausible proxy,
 ;; not a calibrated item-difficulty scale**.
 ;;
-;; ## A real but deliberately non-lexical fixture
+;; ## Real frequency values, not a real vocabulary pool
 
 ^:kindly/hide-code
 (def fixture-text
@@ -107,10 +107,71 @@
 ^:kindly/hide-code
 (def fixture-xs (mapv :x (:pairs transformed-fixture)))
 
-;; The fixture contains source ranks 1–8,000 and their real
-;; `pair_frequency_sn_sum` values. It is **not** a CEFR pool, a Lexibench pool,
-;; or a lexically curated inventory. It exists only to preserve the actual
-;; shape of the frequency predictor during simulation.
+;; Here, **fixture** means a frozen input dataset that makes every simulation
+;; reproducible. "Real" describes only its source ranks 1–8,000, pair IDs, and
+;; observed `pair_frequency_sn_sum` values. The simulation does not use the
+;; pairs' words, meanings, senses, contexts, distractors, or answer choices.
+;;
+;; Nor were these 8,000 pairs curated as a CEFR or Lexibench vocabulary pool:
+;; they were taken by frequency rank, without selecting for learner relevance,
+;; lexical coverage, or item quality. Their highly skewed scores are retained
+;; instead of replaced by invented, evenly spaced frequencies, so the model
+;; sees a realistic numerical predictor range, clustering, and long tail. The
+;; resulting simulations test behaviour over that frequency distribution—not
+;; performance on real Lexibench test items.
+
+;; ### From corpus word-form counts to one lemma–form-pair score
+;;
+;; This section explains the raw frequency quantity used by the model below:
+;; where its counts come from, why an ambiguous surface form must be divided
+;; among lemmas, and what `pair_frequency_sn_sum` means after that division.
+;;
+;; 1. **Combine two counts for the surface form.** SUBTLEX-PL provides an
+;;    upstream field called `freq.sn.sum`: the surface form's count in SUBTLEX-PL's
+;;    subtitle corpus plus its count in the balanced-subcorpus National Corpus
+;;    of Polish (BS–NCP). For a hypothetical surface form seen 700 times in the
+;;    first corpus and 300 times in the second, this combined surface-form count
+;;    is 1,000. At this point it belongs to the surface form, not to a particular
+;;    lemma.
+;; 2. **Split an ambiguous surface form using tagged uses.** SUBTLEX also records
+;;    how often that surface form was tagged with each lemma and part of speech.
+;;    Suppose 90 of every 100 tagged uses belong to lemma A and 10 belong to
+;;    lemma B. The importer uses those shares to divide the combined count:
+;;    900 for the `(surface form, lemma A)` pair and 100 for the `(surface form,
+;;    lemma B)` pair.
+;; 3. **Store one score per pair.** Those allocated values are
+;;    `pair_frequency_sn_sum`. An unambiguous surface form receives its entire
+;;    combined count; when several part-of-speech links point to the same lemma,
+;;    their shares are added before storing the pair score.
+;;
+;; Giving both ambiguous pairs the full 1,000 would duplicate the same corpus
+;; evidence and falsely make both look common. The split is performed on linear
+;; counts because 900 + 100 still equals the original 1,000; logarithms and Zipf
+;; values do not have that additive property. Only after the pair score is
+;; constructed do we take its logarithm and z-score it to obtain $x_i$ below.
+;;
+;; This is an allocated frequency proxy, not a direct count observed separately
+;; for each pair and not calibrated learner difficulty. It distinguishes
+;; lemmas, not senses. It also assumes that SUBTLEX's lemma–part-of-speech shares
+;; are a reasonable way to divide the combined total, even though that total
+;; includes BS–NCP counts.
+
+;; ### Why take the logarithm and then z-score?
+;;
+;; Raw pair-frequency scores span orders of magnitude and are strongly skewed
+;; toward a few very frequent pairs. The base-10 logarithm makes multiplicative
+;; differences easier to compare: 10 to 100 and 100 to 1,000 are both tenfold
+;; increases, so each becomes a step of 1 on the log scale. This stops the
+;; largest raw counts from dominating distance merely because their numbers are
+;; large.
+;;
+;; Z-scoring then describes each log frequency relative to this fixed 8,000-pair
+;; fixture. It subtracts the fixture-wide mean log frequency and divides by its
+;; population standard deviation. The result uses standard-deviation units:
+;; `0` means average log frequency in this fixture, `+1` means one standard
+;; deviation above it, and `-1` means one below it. This gives the later
+;; threshold $t$ and width $w$ an interpretable common scale instead of raw
+;; corpus-count units.
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -128,22 +189,19 @@
   [:section.pf-card
    [:h3 "Bounds after z-scoring"]
    [:p (format "%.3f to %.3f" (apply min fixture-xs) (apply max fixture-xs))]
-   [:p "8 × 1,000 rank-stratified pairs"]]])
+   [:p "8,000 lemma–form-pair scores"]]])
 
-;; For pair $i$:
+;; For pair $i$, let $f_i$ be its `pair_frequency_sn_sum` value. The prose above
+;; and the equation below describe the same two-step transformation:
 ;;
-;; $$x_i = z\!\left(\log_{10}(\text{pair-frequency}_{i})\right)$$
-
-^:kindly/hide-code
-(math/explanation
- "math-standardized-frequency"
- "The pair-frequency predictor"
- [["i" "The index identifying one lemma–surface-form pair."]
-  ["pair-frequency_i" "The corpus frequency recorded for pair i; it distinguishes lemma–form pairs, not word senses."]
-  ["log₁₀" "Base-10 logarithm. It compresses the large, skewed differences between raw frequencies."]
-  ["z(a)" "Z-standardisation: subtract the fixture mean of a and divide by its population standard deviation."]
-  ["x_i" "The resulting standardised log-frequency predictor for pair i, measured in standard-deviation units."]]
- "Higher x_i means higher corpus pair frequency within this fixed, versioned pool. It is still a proxy, not calibrated item difficulty.")
+;; $$x_i =
+;; \frac{\log_{10}(f_i)-\mu_{\log f}}{\sigma_{\log f}}.$$
+;;
+;; Here $\mu_{\log f}$ and $\sigma_{\log f}$ are the mean and population SD
+;; shown in the Transform card. Higher $x_i$ means a more frequent pair within
+;; this fixture. The transformation preserves the pair ordering; it does not
+;; turn frequency into calibrated item difficulty or make scores independent of
+;; the versioned pool used to calculate the mean and SD.
 ;;
 ;; $$p_i = \operatorname{logistic}\!\left(
 ;;     2\log(9)\frac{x_i-t}{w}\right).$$
@@ -161,16 +219,40 @@
   ["log(9)" "The natural logarithm of 9. Together with the factor 2, it makes t − w/2 map to 0.1 and t + w/2 map to 0.9."]]
  "Larger w produces a gentler curve. Higher x_i relative to t produces a larger modelled knowing probability.")
 ;;
-;; The threshold $t$ is the predictor value where $p_i=0.5$. The positive
-;; width $w$ is the predictor distance from 10% to 90%. Larger widths mean a
-;; gentler transition.
+;; The threshold $t$ is a continuous position on the standardised-frequency
+;; scale, not necessarily one observed pair or rank. If a pair has $x_i=t$, the
+;; model assigns it $p_i=0.5$; otherwise $t$ lies between neighbouring pairs.
+;; Because higher $x_i$ means greater frequency, pairs above the threshold get
+;; probabilities above 50% and pairs below it get probabilities below 50% for a
+;; fixed $t$ and $w$. The posterior keeps $t$ uncertain rather than identifying
+;; one definitive "50% pair." The positive width $w$ is the predictor distance
+;; from 10% to 90%; larger widths mean a gentler transition.
+
+;; `v2/knowledge-probability` takes arguments in the order `(x, t, w)` and
+;; returns the modelled probability, between `0` and `1`, that the learner knows
+;; a pair at predictor position $x$. It does not draw a simulated known/unknown
+;; response. The calls below hold $t=0.7$ and $w=2.0$ fixed, then evaluate a
+;; pair at the threshold, half a width below it, and half a width above it.
 
 (def curve-check
   {:at-threshold (v2/knowledge-probability 0.7 0.7 2.0)
    :one-half-width-below (v2/knowledge-probability -0.3 0.7 2.0)
    :one-half-width-above (v2/knowledge-probability 1.7 0.7 2.0)})
 
-;; The executable check returns probabilities `0.5`, `0.1`, and `0.9`.
+;; The returned map therefore contains probabilities `0.5`, `0.1`, and `0.9`.
+;; This checks the curve's parameterisation; it is not fitted learner data.
+;;
+;; The whole calculation in one view:
+
+^:kindly/hide-code
+(kind/mermaid
+ "flowchart TD
+    A[\"Pair i: allocated pair score fᵢ<br/>pair_frequency_sn_sum\"] --> B[\"log₁₀(fᵢ)<br/>compress tenfold gaps\"]
+    B --> X[\"z-score xᵢ<br/>(log fᵢ − μ) / σ\"]
+    F[\"Versioned 8,000-pair fixture<br/>supplies mean μ and SD σ\"] --> X
+    X --> G[\"Logistic curve<br/>2 log(9) × (xᵢ − t) / w\"]
+    T[\"Learner parameters<br/>t: 50% position<br/>w: 10%–90% width\"] --> G
+    G --> P[\"pᵢ<br/>modelled knowledge probability, 0–1\"]")
 ;;
 ;; ## Priors and deterministic grid
 ;;
@@ -253,11 +335,16 @@
 ;; Raw response events remain `:correct`, `:wrong`, or `:dont-know`. V2 still
 ;; maps correct to `1` and both other values to `0` for inference. Tested pair
 ;; outcomes are fixed; posterior-predictive simulation draws outcomes only for
-;; untested pairs. The point estimate is the posterior-predictive mean and the
-;; interval is a deterministic seeded 95% equal-tail interval.
+;; untested pairs. The point estimate is the mean of the resulting whole-pool
+;; totals. The reported 95% equal-tail credible interval runs from their 2.5th
+;; to 97.5th percentiles: conditional on this model and the observed responses,
+;; it is the central range of totals the model considers plausible. A fixed
+;; random seed makes the endpoints reproducible. The interval is not a
+;; guarantee that the learner's true total lies inside it.
 ;;
 ;; The fitted model assumes that unmodelled pair and complete-item effects have
-;; conditional mean zero. Its credible interval does **not** include uncertainty
+;; conditional mean zero. The interval includes uncertainty about the fitted
+;; parameters and untested pair outcomes, but does **not** include uncertainty
 ;; from violating that assumption. Context, distractors, guessing, slips, and
 ;; sense distinctions remain outside this model.
 
@@ -334,16 +421,206 @@
 ^:kindly/hide-code
 (def held-out-candidate (first (:rules held-out-result)))
 
-;; Tuning covered 45 supported cells: expected totals near 10%, 30%, 50%, 70%,
-;; and 90%; widths `0.75`, `1.5`, and `3.0`; and zero-mean pair residual SDs
-;; `0`, `0.5`, and `1.0`. Every cell used 500 replicates. The search crossed 100
-;; complete-round rules.
+^:kindly/hide-code
+(def stress-result
+  (edn/read-string
+   (slurp (io/resource
+           "language_learning/vocabulary_estimation/pair_frequency_logistic_v2_stress.edn"))))
+
+^:kindly/hide-code
+(def tuning-diagnostic-candidate
+  (first (filter #(= (:rule %) (:rule held-out-candidate))
+                 (:rules tuning-result))))
+
+^:kindly/hide-code
+(def simulation-phases
+  [{:phase "Rule tuning"
+    :cells (:supported-cell-count tuning-result)
+    :replicates (:replicates-per-cell tuning-result)
+    :learners (* (:supported-cell-count tuning-result)
+                 (:replicates-per-cell tuning-result))
+    :rules (count (:rules tuning-result))}
+   {:phase "Held-out supported diagnostic"
+    :cells (:supported-cell-count held-out-result)
+    :replicates (:replicates-per-cell held-out-result)
+    :learners (* (:supported-cell-count held-out-result)
+                 (:replicates-per-cell held-out-result))
+    :rules (count (:rules held-out-result))}
+   {:phase "Untuned stress diagnostic"
+    :cells (:stress-cell-count stress-result)
+    :replicates (:replicates-per-cell stress-result)
+    :learners (* (:stress-cell-count stress-result)
+                 (:replicates-per-cell stress-result))
+    :rules 1}])
+
+;; ### What one simulation replicate did
 ;;
-;; No rule satisfied all four requirements. Because there was no eligible rule,
-;; the 2,000-replicate-per-cell run below is a **held-out diagnostic**, not a
-;; promotion gate. Following the declared priority—coverage, then MAE, then
-;; length—it examines the least-bad coverage rule: minimum 48, 7.5% target
-;; half-width, cap 64.
+;; One replicate represents one possible learner-specific pattern of knowledge
+;; across the complete 8,000-pair fixture. It is more than a simulated sequence
+;; of quiz answers: because all 8,000 latent outcomes are generated first, the
+;; simulation knows the learner's realised total and can check an estimate
+;; against that otherwise hidden truth.
+;;
+;; 1. Start with the fixture's 8,000 real standardised log-frequency values.
+;; 2. Choose one scenario cell: a target total, curve width, and residual or
+;;    measurement condition. Numerically move the threshold until the
+;;    scenario's no-random-residual expected total matches the target.
+;; 3. For every pair, calculate its knowing probability and make one Bernoulli
+;;    draw. The sum of those 8,000 binary outcomes is the realised truth for
+;;    that replicate; it varies around the nominal target.
+;; 4. Read the outcomes of the pairs in the phase's balanced, non-adaptive
+;;    schedule. In stress scenarios, optionally flip some latent outcomes to
+;;    create measured responses with false positives or false negatives.
+;; 5. Feed exactly the same response prefix to v1 and v2 after each complete
+;;    eight-item round. Each model produces a count estimate, a 95% interval,
+;;    and a response log score.
+;; 6. Apply a candidate stopping rule at those checkpoints. Record whether the
+;;    final interval contains the realised 8,000-pair truth, the signed and
+;;    absolute count error, interval width, response log score, and quiz length.
+
+^:kindly/hide-code
+(kind/mermaid
+ "flowchart TD
+    F[Fixed 8,000-pair frequency fixture] --> C[Choose one scenario cell]
+    C --> K[Draw all 8,000 latent known or unknown outcomes]
+    K --> T[Save their sum as the realised truth]
+    K --> R[Reveal scheduled pair responses one balanced round at a time]
+    R --> S[Score the same prefixes with v1 and v2]
+    S --> D[Stop by the candidate rule]
+    T --> M[Measure coverage, error, interval width, log score, and length]
+    D --> M")
+
+;; Within a phase, one seeded 160-item schedule was reused for every cell and
+;; replicate. This paired the model comparisons and made the run deterministic.
+;; Tuning, held-out, and stress phases used different seeds and therefore
+;; different schedules. A limitation is that each phase is still conditional
+;; on one item schedule; these runs did not average over many independently
+;; drawn selection schedules.
+
+;; ### What varied in the 45 supported cells
+;;
+;; Tuning crossed all values in the following table. The target is exact for
+;; the baseline curve before random pair residuals and Bernoulli draws, hence
+;; "nominal": the realised total in any replicate is not forced to equal it.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.pf-table-wrap
+  [:table.pf-table.pf-explain-table
+   [:caption.pf-sr-only "Supported simulation-cell dimensions"]
+   [:thead
+    [:tr [:th {:scope "col"} "Dimension"]
+     [:th {:scope "col"} "Values"]
+     [:th {:scope "col"} "Question asked"]]]
+   [:tbody
+    [:tr [:th {:scope "row"} "Nominal known fraction"]
+     [:td "10%, 30%, 50%, 70%, 90%"]
+     [:td "Does performance hold for small, middle, and large vocabularies?"]]
+    [:tr [:th {:scope "row"} "10%–90% curve width"]
+     [:td "0.75, 1.5, 3.0 SD"]
+     [:td "Does performance hold for steep and gradual frequency transitions?"]]
+    [:tr [:th {:scope "row"} "Independent pair residual SD"]
+     [:td "0, 0.5, 1.0 log-odds"]
+     [:td "What if otherwise similar-frequency pairs differ for unmodelled reasons?"]]]]])
+
+;; A residual was drawn independently for every pair in every replicate and
+;; added to its log odds before the latent outcome was drawn. An SD of `0` is
+;; the fitted v2 family exactly. At SD `1`, a one-SD residual multiplies the
+;; pair's odds by about `e¹ = 2.72`, so this is substantial unmodelled
+;; heterogeneity. It is not a persistent item calibration effect shared across
+;; simulated learners.
+;;
+;; ### How stopping rules were tuned
+;;
+;; The search crossed minimum lengths `24`, `32`, `40`, and `48`; interval
+;; half-width targets `5%`, `7.5%`, `10%`, `12.5%`, and `15%` of the pool; and
+;; soft caps `64`, `80`, `96`, `128`, and `160`. This produced 100 valid rules.
+;; A rule stopped at the first complete-round checkpoint at which its width
+;; target was met, or at its cap.
+;;
+;; Each rule had to pass all five checks below. Aggregate checks prevent a noisy
+;; single cell from dominating; cellwise checks prevent good averages from
+;; hiding a subgroup in which the new scorer is poorly calibrated or less
+;; accurate than v1.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.pf-table-wrap
+  [:table.pf-table.pf-explain-table
+   [:caption.pf-sr-only "Precommitted v2 promotion requirements"]
+   [:thead
+    [:tr [:th {:scope "col"} "Check"]
+     [:th {:scope "col"} "Requirement"]
+     [:th {:scope "col"} "Purpose"]]]
+   [:tbody
+    [:tr [:th {:scope "row"} "Aggregate interval coverage"]
+     [:td "≥94.5%"]
+     [:td "Keep the nominal 95% interval honest overall"]]
+    [:tr [:th {:scope "row"} "Every-cell interval coverage"]
+     [:td "≥94%"]
+     [:td "Protect each ability × width × residual condition"]]
+    [:tr [:th {:scope "row"} "Aggregate MAE"]
+     [:td "Lower than v1"]
+     [:td "Improve average count accuracy"]]
+    [:tr [:th {:scope "row"} "Every-cell MAE"]
+     [:td "≤105% of v1"]
+     [:td "Do not buy average gains with a large local regression"]]
+    [:tr [:th {:scope "row"} "Median quiz length"]
+     [:td "No longer than v1"]
+     [:td "Do not require more answers for the gain"]]]]])
+
+;; The 500-replicate tuning run therefore generated 22,500 independent
+;; learner-pool realisations—not 2.25 million. The same 22,500 response streams
+;; were rescored under all 100 rules, which makes rule comparisons paired.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.pf-table-wrap
+  [:table.pf-table
+   [:caption.pf-sr-only "Simulation phases and replicate counts"]
+   [:thead
+    [:tr [:th {:scope "col"} "Phase"]
+     [:th {:scope "col"} "Cells"]
+     [:th {:scope "col"} "Replicates / cell"]
+     [:th {:scope "col"} "Simulated learner-pools"]
+     [:th {:scope "col"} "Rules scored"]]]
+   [:tbody
+    (for [{:keys [phase cells replicates learners rules]} simulation-phases]
+      [:tr {:key phase}
+       [:th {:scope "row"} phase]
+       [:td cells]
+       [:td (format "%,d" replicates)]
+       [:td (format "%,d" learners)]
+       [:td rules]])
+    [:tr
+     [:th {:scope "row"} "Total"]
+     [:td "150 cell-phases"]
+     [:td "—"]
+     [:td (format "%,d" (reduce + (map :learners simulation-phases)))]
+     [:td "—"]]]]])
+
+;; The stress phase was diagnostic only. The promotion decision had already
+;; failed in tuning; neither held-out nor stress results were used to retune v2.
+;;
+;; ### What tuning selected for diagnosis
+;;
+;; No rule satisfied all five checks. The rule with the best worst-cell
+;; coverage started at 48 items, targeted a 7.5%-of-pool half-width, and capped
+;; at 64. In tuning it achieved 95.48% aggregate coverage and MAE 253.0, but its
+;; worst cell covered only 92.4%, its worst cell's MAE was 22.0% above v1, and
+;; its median length was 64 rather than v1's 40. It was therefore not eligible
+;; for promotion.
+;;
+;; Because there was no eligible rule, the 2,000-replicate-per-cell run below is
+;; a **held-out diagnostic**, not a promotion gate. Following the declared
+;; priority—coverage, then MAE, then length—it examines that least-bad coverage
+;; rule: minimum 48, 7.5% target half-width, cap 64.
+;;
+;; "Coverage" is the percentage of replicates whose reported 95% interval
+;; contains the realised 8,000-pair truth. Bias is mean estimate minus truth;
+;; MAE is the mean absolute size of that error. The response log score measures
+;; probability assigned to the observed answers; larger (less negative) is
+;; better. It evaluates response prediction, not count calibration by itself.
 
 ^:kindly/hide-code
 (kind/hiccup
@@ -399,6 +676,22 @@
 ;; worst-cell MAE was `21.1%` worse than v1, and median length was `64` rather
 ;; than `40`. The decision is therefore unambiguous: **retain v1**.
 ;;
+;; Concretely, the weakest cell covered 1,839 of 2,000 realised truths and
+;; missed 161. Its Monte Carlo standard error is about 0.61 percentage points,
+;; so the 2.05-point miss against the 94% threshold is not a one- or two-draw
+;; wobble. Aggregate MAE can still improve while one cell regresses: that is
+;; exactly why both aggregate and cellwise checks were declared. A median of 64
+;; means at least half of v2 diagnostic runs used 64 answers, versus a v1
+;; median of 40.
+;;
+;; V1's poor aggregate coverage here is not evidence that v1 has passed a
+;; realistic validation study. These supported scenarios deliberately generate
+;; smooth frequency curves, so they are favourable to v2 and unfavourable to
+;; v1's eight separate, sparsely observed rates—especially near 10% and 90%.
+;; The question was narrower: even under favourable synthetic conditions, did
+;; v2 meet absolute coverage requirements, avoid materially worse cells, and
+;; shorten or preserve test length? It did not.
+;;
 ;; ## Untuned stress diagnostics
 ;;
 ;; I froze the same diagnostic rule, then ran 2,000 replicates per cell without
@@ -409,10 +702,35 @@
 ;; `:precision-target` or `:soft-maximum` under the frozen 48 / 7.5% / 64 rule.
 
 ^:kindly/hide-code
-(def stress-result
-  (edn/read-string
-   (slurp (io/resource
-           "language_learning/vocabulary_estimation/pair_frequency_logistic_v2_stress.edn"))))
+(kind/hiccup
+ [:div.pf-table-wrap
+  [:table.pf-table.pf-explain-table
+   [:caption.pf-sr-only "Stress simulation mechanisms"]
+   [:thead
+    [:tr [:th {:scope "col"} "Stress"]
+     [:th {:scope "col"} "How responses were generated"]
+     [:th {:scope "col"} "What it probes"]]]
+   [:tbody
+    [:tr [:th {:scope "row"} "Non-logistic mixture"]
+     [:td "Average of a steep curve (width 0.75, threshold t−0.6) and a gentle curve (width 3.0, threshold t+0.6)."]
+     [:td "A monotone frequency relationship that one logistic curve cannot exactly represent."]]
+    [:tr [:th {:scope "row"} "Frequency-related residual"]
+     [:td "Add either −0.75x or +0.75x to the baseline log odds."]
+     [:td "An omitted systematic frequency component that weakens or strengthens the fitted slope."]]
+    [:tr [:th {:scope "row"} "False positive"]
+     [:td "Flip a latent unknown pair to a correct response with probability 2%, 5%, or 10%."]
+     [:td "Guessing-like responses; truth remains the latent known count."]]
+    [:tr [:th {:scope "row"} "False negative"]
+     [:td "Flip a latent known pair to an incorrect response with probability 2%, 5%, or 10%."]
+     [:td "Slip or measurement failure; truth remains the latent known count."]]
+    [:tr [:th {:scope "row"} "Rank-increasing error"]
+     [:td "Increase both flip rates linearly from 0 at the most frequent end to 2%, 5%, or 10% at rank 8,000."]
+     [:td "Measurement quality that worsens systematically toward rarer pairs."]]]]])
+
+;; Each mechanism was crossed with all five nominal ability targets. The
+;; mixture therefore contributed 5 cells, the two residual slopes 10, and each
+;; three-rate error family 15: 60 cells and 120,000 new learner-pool
+;; realisations in total.
 
 ^:kindly/hide-code
 (def stress-labels
@@ -480,6 +798,11 @@
                     (:one-half-width-above curve-check)])))
   (assert (get-in grid-check [:convergence :passes?]))
   (assert (empty? (filter :passes? (:rules tuning-result))))
+  (assert (= tuning-diagnostic-candidate
+             (apply max-key :minimum-cell-coverage (:rules tuning-result))))
+  (assert (= 232500 (reduce + (map :learners simulation-phases))))
   (assert (not (:passes? held-out-candidate)))
+  (assert (= 1839 (long (* (:replicates-per-cell held-out-result)
+                           (:minimum-cell-coverage held-out-candidate)))))
   (assert (= 60 (:stress-cell-count stress-result)))
   :verified-negative-result)

--- a/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_article.clj
+++ b/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_article.clj
@@ -20,7 +20,27 @@
 ^:kindly/hide-code
 (kind/hiccup
  [:style
-  ".pf-callout{border-left:4px solid #2780e3;background:#f2f7fc;color:#17202a;padding:1rem 1.15rem;margin:1.35rem 0;border-radius:.3rem}.pf-callout.fail{border-color:#c44536;background:#fff1ef}.pf-callout.provisional{border-color:#e69f00;background:#fff8e6}.pf-callout strong{display:block;margin-bottom:.3rem}.pf-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}.pf-card{min-width:0;border:1px solid #dee2e6;border-radius:.55rem;padding:1rem;background:var(--bs-body-bg,#fff)}.pf-card h3{font-size:1rem;margin:0 0 .4rem}.pf-card p{margin:.25rem 0}.pf-table-wrap{overflow-x:auto;margin:1.25rem 0}.pf-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}.pf-table th,.pf-table td{padding:.55rem .7rem;border-bottom:1px solid #dee2e6;text-align:right;white-space:nowrap}.pf-table th:first-child,.pf-table td:first-child{text-align:left}.pf-table thead th{border-bottom:2px solid #adb5bd}.pf-explain-table th,.pf-explain-table td{white-space:normal;text-align:left;vertical-align:top;min-width:9rem}.pf-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.pf-code{overflow-wrap:anywhere}.pf-lab{border:1px solid #ced4da;border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}.series-toc{min-width:0;border:1px solid #ced4da;border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:1.4rem 0;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem 0}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:#4f5b66}.quarto-dark .series-status{color:#b9c7d2}@media(max-width:575px){.pf-table th,.pf-table td{padding:.45rem}.pf-card{padding:.8rem}}"])
+  (str
+   ":root{--pf-accent:#1464b5;--pf-accent-soft:#e6f1fb;--pf-fail:#a72f24;--pf-fail-soft:#fdeae7;--pf-warn:#8a5000;--pf-warn-soft:#fff0d8;--pf-success:#0f695f;--pf-success-soft:#e2f4f0;--pf-muted:#4f5b66}"
+   ".quarto-dark{--pf-accent:#73b7ff;--pf-accent-soft:#173653;--pf-fail:#ff998f;--pf-fail-soft:#4a211e;--pf-warn:#ffc46f;--pf-warn-soft:#493216;--pf-success:#64d8c7;--pf-success-soft:#163d38;--pf-muted:#b9c7d2}"
+   ".pf-callout{border:1px solid color-mix(in srgb,var(--pf-accent) 45%,var(--bs-border-color,#dee2e6));border-left:4px solid var(--pf-accent);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--pf-accent) 10%);color:var(--bs-body-color,#212529);padding:1rem 1.15rem;margin:1.35rem 0;border-radius:.35rem}"
+   ".pf-callout.fail{border-color:color-mix(in srgb,var(--pf-fail) 60%,var(--bs-border-color,#dee2e6));border-left-color:var(--pf-fail);background:color-mix(in srgb,var(--bs-body-bg,#fff) 88%,var(--pf-fail) 12%)}"
+   ".pf-callout.provisional{border-color:color-mix(in srgb,var(--pf-warn) 60%,var(--bs-border-color,#dee2e6));border-left-color:var(--pf-warn);background:color-mix(in srgb,var(--bs-body-bg,#fff) 90%,var(--pf-warn) 10%)}"
+   ".pf-callout strong{display:block;margin-bottom:.3rem}.pf-callout p:last-child{margin-bottom:0}"
+   ".pf-grid,.pf-definition-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,15rem),1fr));gap:1rem;margin:1.25rem 0}"
+   ".pf-card,.pf-definition{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.55rem;padding:1rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529);overflow-wrap:anywhere}"
+   ".pf-card h3{font-size:1rem;margin:0 0 .4rem}.pf-card p{margin:.25rem 0}.pf-definition dt{font-weight:800;color:var(--pf-accent)}.pf-definition dd{margin:.25rem 0 0}"
+   ".pf-table-wrap{max-width:100%;overflow-x:auto;margin:1.25rem 0}.pf-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}"
+   ".pf-table th,.pf-table td{padding:.55rem .7rem;border-bottom:1px solid var(--bs-border-color,#dee2e6);text-align:right;white-space:nowrap}.pf-table th:first-child,.pf-table td:first-child{text-align:left}.pf-table thead th{border-bottom:2px solid var(--bs-border-color,#adb5bd)}"
+   ".pf-explain-table th,.pf-explain-table td{white-space:normal;text-align:left;vertical-align:top;min-width:9rem}"
+   ".pf-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.pf-code{overflow-wrap:anywhere}.pf-lab{border:1px solid var(--bs-border-color,#ced4da);border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);min-width:0}"
+   ".pf-pipeline{display:grid;grid-template-columns:repeat(9,minmax(0,auto));align-items:stretch;gap:.4rem;margin:1.25rem 0}.pf-stage{display:grid;align-content:center;min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.7rem;background:var(--bs-body-bg,#fff);text-align:center;overflow-wrap:anywhere}.pf-stage strong{display:block;color:var(--pf-accent)}.pf-stage small{color:var(--pf-muted)}.pf-arrow{display:grid;place-items:center;color:var(--pf-accent);font-size:1.35rem;font-weight:800}"
+   ".pf-diagram{min-width:0;margin:1.25rem 0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.55rem;padding:clamp(.75rem,2vw,1rem);background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.pf-diagram-steps{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,9rem),1fr));gap:.65rem;margin:0;padding:0;list-style:none;counter-reset:pf-step}.pf-diagram-steps li{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.65rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 94%,var(--pf-accent) 6%);overflow-wrap:anywhere;counter-increment:pf-step}.pf-diagram-steps li::before{content:counter(pf-step);display:grid;place-items:center;width:1.55rem;height:1.55rem;margin-bottom:.4rem;border-radius:50%;background:var(--pf-accent);color:var(--bs-body-bg,#fff);font-weight:800}.quarto-dark .pf-diagram-steps li::before{color:#10212b}.pf-diagram-steps strong,.pf-lane strong{display:block;color:var(--pf-accent)}"
+   ".pf-phase-diagram{display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);gap:.65rem;align-items:center}.pf-phase-node,.pf-phase-branch{min-width:0}.pf-phase-node{border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.75rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 94%,var(--pf-accent) 6%);overflow-wrap:anywhere}.pf-phase-node strong{display:block;color:var(--pf-accent)}.pf-phase-branch{display:grid;gap:.55rem}.pf-workflow-lanes{display:grid;gap:.8rem}.pf-lane{min-width:0;border-left:4px solid var(--pf-accent);padding:.2rem 0 .2rem .8rem}.pf-lane h3{font-size:1rem;margin:.1rem 0 .55rem}"
+   ".pf-odds-strip{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.65rem;margin:1rem 0}.pf-odds-card{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.7rem;background:var(--bs-body-bg,#fff);text-align:center}.pf-odds-card strong,.pf-odds-card span{display:block}.pf-odds-card strong{color:var(--pf-accent)}.pf-odds-card span{font-variant-numeric:tabular-nums}"
+   ".pf-status-pass{color:var(--pf-success);font-weight:800}.pf-status-fail{color:var(--pf-fail);font-weight:800}.pf-caption,.pf-note{font-size:.9rem;color:var(--pf-muted)}"
+   ".series-toc{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.6rem;padding:clamp(.85rem,3vw,1.2rem);margin:0 0 1.4rem;background:var(--bs-body-bg,#fff)}.series-toc h2{font-size:1.2rem;margin:0 0 .55rem}.series-toc p{margin:0 0 .7rem}.series-toc ol{margin:0;padding-left:1.45rem}.series-toc li{padding:.18rem .45rem}.series-status{display:inline-block;margin-left:.35rem;font-size:.7rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--pf-muted)}.series-current{margin:.35rem 0 .35rem -.7rem;border-left:4px solid var(--pf-accent);border-radius:.4rem;padding:.6rem .75rem!important;background:color-mix(in srgb,var(--bs-body-bg,#fff) 84%,var(--pf-accent) 16%);box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--pf-accent) 35%,transparent);font-weight:700}.series-current>a{color:var(--pf-accent)}.series-current .series-status{border-radius:999px;padding:.18rem .48rem;background:var(--pf-accent);color:#fff}.quarto-dark .series-current .series-status{color:#10212b}"
+   "@media(max-width:767px){.pf-pipeline,.pf-phase-diagram{grid-template-columns:minmax(0,1fr)}.pf-arrow{min-height:1rem}.pf-odds-strip{grid-template-columns:minmax(0,1fr)}}@media(max-width:575px){.pf-table th,.pf-table td{padding:.45rem}.pf-card{padding:.8rem}}")])
 
 ^:kindly/hide-code
 (math/styles)
@@ -38,9 +58,10 @@
    [:li [:a {:href "beta_binomial_first_pass.html"}
          "Estimating Vocabulary Size with a Simple Bayesian Model"]
     [:span.series-status "published"]]
-   [:li [:a {:href "pair_frequency_logistic_v2_article.html"}
-         "Does Pair Frequency Predict Learner Responses?"]
-    [:span.series-status "current"]]
+   [:li.series-current [:a {:href "pair_frequency_logistic_v2_article.html"
+                            :aria-current "page"}
+                        "Does Pair Frequency Predict Learner Responses?"]
+    [:span.series-status "you are here"]]
    [:li "From Self-Reported CEFR to a Versioned Lemma–Form-Pair Pool"
     [:span.series-status "planned"]]
    [:li "From Correlated Form Pairs to Latent Lemma Knowledge"
@@ -55,7 +76,7 @@
 ^:kindly/hide-code
 (math/global-controls)
 
-;; ## A useful model that did not earn promotion
+;; ## The result first: useful, but not promoted
 ;;
 ;; The first post estimated a separate knowing rate in each of eight frequency
 ;; strata. This follow-up removes those artificial difficulty steps. It asks
@@ -67,6 +88,36 @@
  [:div.pf-callout.fail
   [:strong "Result: do not promote v2"]
   "No candidate stopping rule passed the precommitted tuning gate. The target contract therefore remains stratified Beta–binomial v1. This is a negative model-development result, not evidence that frequency contains no signal."])
+
+;; Three decision terms matter from the start:
+
+^:kindly/hide-code
+(kind/hiccup
+ [:dl.pf-definition-grid
+  [:div.pf-definition
+   [:dt "Gate"]
+   [:dd "A set of acceptance checks declared before seeing the results. Every check must pass."]]
+  [:div.pf-definition
+   [:dt "Promotion"]
+   [:dd "Replacing the current target scorer, v1, with the candidate scorer, v2."]]
+  [:div.pf-definition
+   [:dt "Non-promotion"]
+   [:dd "Keeping v1 because v2 failed the gate—without weakening the checks after seeing the result."]]])
+
+;; The outcome is deliberately asymmetric: a candidate may teach us something
+;; and still fail to earn operational trust. Here the historical gate used
+;; logical **AND**: passing four checks would still have meant non-promotion.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:ol.article-chapter-map
+  [:li [:strong "Construct"] [:br] "Turn corpus counts into one predictor per pair."]
+  [:li [:strong "Curve"] [:br] "Connect frequency to probability through odds and log odds."]
+  [:li [:strong "Infer"] [:br] "Use priors and a deterministic grid while separating latent and observed outcomes."]
+  [:li [:strong "Select"] [:br] "Keep the balanced response-independent schedule unchanged."]
+  [:li [:strong "Simulate"] [:br] "Separate replicates, phases, metrics, and seeds."]
+  [:li [:strong "Gate"] [:br] "Apply all five precommitted checks."]
+  [:li [:strong "Decide"] [:br] "Diagnose the failure and retain v1."]])
 
 ;; External evidence makes frequency a reasonable provisional predictor, but
 ;; does not calibrate Lexibench's Polish lemma–surface-form pairs:
@@ -156,6 +207,24 @@
 ;; are a reasonable way to divide the combined total, even though that total
 ;; includes BS–NCP counts.
 
+^:kindly/hide-code
+(kind/hiccup
+ [:figure
+  [:div.pf-pipeline
+   {:role "img"
+    :aria-label "Frequency construction pipeline. Add subtitle and balanced-corpus surface-form counts. Split an ambiguous form among lemmas using tagged-use shares. Store one allocated pair score. Take its base-ten logarithm. Standardize it using the fixture mean and population standard deviation."}
+   [:div.pf-stage [:strong "Corpus counts"] [:span "700 + 300"] [:small "surface form = 1,000"]]
+   [:div.pf-arrow {:aria-hidden "true"} "→"]
+   [:div.pf-stage [:strong "Ambiguous-form split"] [:span "90% / 10%"] [:small "tagged lemma shares"]]
+   [:div.pf-arrow {:aria-hidden "true"} "→"]
+   [:div.pf-stage [:strong "Pair score"] [:span "900 and 100"] [:small "pair_frequency_sn_sum"]]
+   [:div.pf-arrow {:aria-hidden "true"} "→"]
+   [:div.pf-stage [:strong "Log transform"] [:span "log₁₀(fᵢ)"] [:small "compress tenfold gaps"]]
+   [:div.pf-arrow {:aria-hidden "true"} "→"]
+   [:div.pf-stage [:strong "Z-score"] [:span "xᵢ = (log fᵢ − μ) / σ"] [:small "fixture-relative SD units"]]]
+  [:figcaption.pf-caption
+   "The first three steps conserve the original linear count. Logging and standardising happen only after the evidence has been allocated to pairs."]])
+
 ;; ### Why take the logarithm and then z-score?
 ;;
 ;; Raw pair-frequency scores span orders of magnitude and are strongly skewed
@@ -202,6 +271,39 @@
 ;; this fixture. The transformation preserves the pair ordering; it does not
 ;; turn frequency into calibrated item difficulty or make scores independent of
 ;; the versioned pool used to calculate the mean and SD.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-frequency-transform"
+ "Constructing the standardised pair-frequency predictor"
+ [:div
+  [:p "The transform logs every positive pair score, calculates the fixture-wide mean and population SD, then attaches x to each immutable pair record."]
+  [:pre [:code "(defn frequency-transform [pairs]\n  (let [logs (mapv #(Math/log10 (:pair-frequency-sn-sum %)) pairs)\n        location (mean logs)\n        scale (population-sd logs)]\n    {:log10-mean location\n     :log10-population-sd scale\n     :pairs (mapv (fn [pair log-frequency]\n                    (assoc pair :x (/ (- log-frequency location) scale)))\n                  pairs logs)}))"]]
+  [:p "The fixture validator separately rejects non-positive frequencies, duplicate pair IDs, and rank drift before this function runs."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2.cljc"}
+    "View the transform and fixture validation"]]])
+;;
+;; ## From probability to a logistic curve
+;;
+;; A **probability** $p$ describes expected successes out of all comparable
+;; cases. **Odds** compare successes with failures: $p/(1-p)$. A probability of
+;; 0.9 means odds of 9 to 1; 0.1 means 1 to 9. **Log odds** take the natural
+;; logarithm of the odds. They are negative below 50%, zero at 50%, and positive
+;; above 50%. A logistic curve turns any real-valued log odds back into a
+;; probability between 0 and 1.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:figure
+  [:div.pf-odds-strip
+   {:role "img"
+    :aria-label "Three points on the logistic curve. Half a transition width below the threshold gives probability 0.1, odds 1 to 9, and log odds minus 2.20. At the threshold gives probability 0.5, odds 1 to 1, and log odds zero. Half a width above gives probability 0.9, odds 9 to 1, and log odds 2.20."}
+   [:div.pf-odds-card [:strong "x = t − w/2"] [:span "p = 0.10"] [:span "odds 1:9"] [:span "log odds −2.20"]]
+   [:div.pf-odds-card [:strong "x = t"] [:span "p = 0.50"] [:span "odds 1:1"] [:span "log odds 0"]]
+   [:div.pf-odds-card [:strong "x = t + w/2"] [:span "p = 0.90"] [:span "odds 9:1"] [:span "log odds +2.20"]]]
+  [:figcaption.pf-caption
+   "The curve explorer below uses these same three anchor points. Move t to shift them together; move w to spread or compress them."]])
 ;;
 ;; $$p_i = \operatorname{logistic}\!\left(
 ;;     2\log(9)\frac{x_i-t}{w}\right).$$
@@ -231,9 +333,10 @@
 ;; `v2/knowledge-probability` takes arguments in the order `(x, t, w)` and
 ;; returns the modelled probability, between `0` and `1`, that the learner knows
 ;; a pair at predictor position $x$. It does not draw a simulated known/unknown
-;; response. The calls below hold $t=0.7$ and $w=2.0$ fixed, then evaluate a
-;; pair at the threshold, half a width below it, and half a width above it.
+;; response. The executable check below holds $t=0.7$ and $w=2.0$ fixed, then
+;; evaluates the three annotated positions.
 
+^:kindly/hide-code
 (def curve-check
   {:at-threshold (v2/knowledge-probability 0.7 0.7 2.0)
    :one-half-width-below (v2/knowledge-probability -0.3 0.7 2.0)
@@ -242,17 +345,31 @@
 ;; The returned map therefore contains probabilities `0.5`, `0.1`, and `0.9`.
 ;; This checks the curve's parameterisation; it is not fitted learner data.
 ;;
-;; The whole calculation in one view:
+^:kindly/hide-code
+(math/code-detail
+ "code-logistic-probability"
+ "Turning predictor position into knowing probability"
+ [:div
+  [:p "The stable logistic implementation avoids overflow for very large positive or negative log odds. Width must be positive."]
+  [:pre [:code "(defn logistic [z]\n  (if (neg? z)\n    (let [e (Math/exp z)] (/ e (+ 1.0 e)))\n    (/ 1.0 (+ 1.0 (Math/exp (- z))))))\n\n(defn knowledge-probability [x threshold width]\n  (when-not (pos? width)\n    (throw (ex-info \"Transition width must be positive\" {:width width})))\n  (logistic (/ (* transition-logit-span (- x threshold)) width)))"]]
+  [:p "The factor 2 log(9) makes the two half-width points exactly 0.1 and 0.9."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2.cljc"}
+    "View the probability functions and parity tests"]]])
+;;
+;; ### Explore the curve
+;;
+;; Read the horizontal axis as pair frequency relative to this fixture and the
+;; vertical axis as modelled knowing probability. Before moving a slider,
+;; predict what will happen: threshold should slide the 50% point left or right;
+;; width should change the distance between the 10% and 90% points.
 
 ^:kindly/hide-code
-(kind/mermaid
- "flowchart TD
-    A[\"Pair i: allocated pair score fᵢ<br/>pair_frequency_sn_sum\"] --> B[\"log₁₀(fᵢ)<br/>compress tenfold gaps\"]
-    B --> X[\"z-score xᵢ<br/>(log fᵢ − μ) / σ\"]
-    F[\"Versioned 8,000-pair fixture<br/>supplies mean μ and SD σ\"] --> X
-    X --> G[\"Logistic curve<br/>2 log(9) × (xᵢ − t) / w\"]
-    T[\"Learner parameters<br/>t: 50% position<br/>w: 10%–90% width\"] --> G
-    G --> P[\"pᵢ<br/>modelled knowledge probability, 0–1\"]")
+(kind/hiccup
+ [:div.pf-lab
+  [:div#pair-frequency-curve-explorer
+   [:p "Loading the curve explorer…"]]
+  [:noscript "This explorer needs JavaScript."]])
 ;;
 ;; ## Priors and deterministic grid
 ;;
@@ -287,7 +404,31 @@
 ;;
 ;; These are provisional. The posterior is evaluated on 161 threshold points
 ;; from `min(x)-2` to `max(x)+2`, crossed with 81 log-spaced widths from `0.25`
-;; to `8`. Log weights are normalized with log-sum-exp.
+;; to `8`. A **prior** states relative plausibility before this learner's
+;; responses. A **deterministic parameter grid** lists the same 13,041
+;; $(t,w)$ candidates on every run. It replaces a continuous search with a
+;; fixed approximation that can be replayed exactly.
+;;
+;; For a binary outcome $y_i$—1 for correct, 0 otherwise—the likelihood at one
+;; grid point is:
+;;
+;; $$L(t,w)=\prod_i p_i^{y_i}(1-p_i)^{1-y_i}.$$
+
+^:kindly/hide-code
+(math/explanation
+ "math-grid-likelihood"
+ "The likelihood at one parameter-grid point"
+ [["L(t,w)" "How well one threshold-and-width candidate predicts all observed binary outcomes."]
+  ["∏ᵢ" "Multiply one response contribution for every tested pair i."]
+  ["pᵢ" "The logistic knowing probability for tested pair i at this grid point."]
+  ["yᵢ" "The observed binary outcome: 1 for correct and 0 for wrong or don’t-know in v2."]
+  ["pᵢʸⁱ(1−pᵢ)¹⁻ʸⁱ" "Selects pᵢ after a correct response and 1−pᵢ otherwise."]]
+ "In plain English: candidates that assign higher probability to the responses actually seen receive more likelihood weight.")
+;;
+;; The implementation adds log likelihoods to log prior weights, then uses
+;; **log-sum-exp** to normalise them safely into posterior probabilities that
+;; sum to 1. A wider grid check later repeats the calculation with 321×161
+;; points to test whether the default numerical resolution changes the answer.
 
 ^:kindly/hide-code
 (def wider-prior
@@ -320,17 +461,27 @@
 ;; The prior is broad on the count scale; doubling both prior standard
 ;; deviations makes it more extreme. Neither prior was learned from Lexibench
 ;; responses.
-;;
-;; ### Explore the curve
 
 ^:kindly/hide-code
-(kind/hiccup
- [:div.pf-lab
-  [:div#pair-frequency-curve-explorer
-   [:p "Loading the curve explorer…"]]
-  [:noscript "This explorer needs JavaScript."]])
+(math/code-detail
+ "code-parameter-grid-likelihood"
+ "Weighting the deterministic parameter grid by response likelihood"
+ [:div
+  [:p "Each grid candidate receives its log prior plus the sum of Bernoulli log likelihoods. Normalisation is performed only after all candidates have been scored."]
+  [:pre [:code "(defn posterior-grid [xs observations grid prior]\n  (let [parameters (parameter-grid xs grid prior)\n        log-weights\n        (mapv (fn [{:keys [threshold width log-prior]}]\n                (+ log-prior\n                   (log-likelihood observations threshold width)))\n              parameters)\n        weights (normalize-log-weights log-weights)]\n    (mapv #(assoc %1 :weight %2) parameters weights)))"]]
+  [:p "The browser demonstration deliberately uses 41×21 points; the authoritative CLJ path keeps 161×81."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2.cljc"}
+    "View the parameter grid, likelihood, and normalisation"]]])
 
 ;; ## What is observed and what is predicted
+;;
+;; **Latent knowledge** is the unobserved known-or-unknown state the model tries
+;; to infer for each pair. An **observed outcome** is what the quiz recorded.
+;; Those are not interchangeable: a learner can guess, slip, misunderstand a
+;; context, or meet a poor distractor. A **prediction** is what the fitted model
+;; says about an untested pair or future response; it is neither an observation
+;; nor direct access to the latent state.
 ;;
 ;; Raw response events remain `:correct`, `:wrong`, or `:dont-know`. V2 still
 ;; maps correct to `1` and both other values to `0` for inference. Tested pair
@@ -342,11 +493,20 @@
 ;; random seed makes the endpoints reproducible. The interval is not a
 ;; guarantee that the learner's true total lies inside it.
 ;;
-;; The fitted model assumes that unmodelled pair and complete-item effects have
-;; conditional mean zero. The interval includes uncertainty about the fitted
-;; parameters and untested pair outcomes, but does **not** include uncertainty
-;; from violating that assumption. Context, distractors, guessing, slips, and
-;; sense distinctions remain outside this model.
+;; ### Residual variation and misspecification
+;;
+;; A **residual** is the difference left after the frequency curve has made its
+;; prediction. Two pairs with the same $x$ can still differ because of the word,
+;; context, answer choices, or learner history. The supported simulation added
+;; independent mean-zero residual variation to log odds. That tests noisy local
+;; departures, not persistent calibrated item effects.
+;;
+;; **Model misspecification** means the assumed probability model does not match
+;; the process generating outcomes. The fitted v2 interval includes uncertainty
+;; about $(t,w)$ and untested binary outcomes. It does **not** automatically
+;; widen for a wrong curve shape, systematic residuals, guessing, slips,
+;; context, distractors, or sense distinctions. Stress simulations introduce
+;; some of those mismatches explicitly later.
 
 ^:kindly/hide-code
 (def grid-check
@@ -384,6 +544,24 @@
 ;; rank strata. Each complete round selects one unseen pair per stratum and
 ;; records its inclusion probability. Responses update inference only; they do
 ;; not alter item order. Adaptive selection remains a non-goal.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div#pair-frequency-response-inference-simulator
+  [:p "Loading the response-and-schedule demonstration…"]
+  [:noscript "This demonstration needs JavaScript. The seeded schedule remains response-independent."]])
+
+^:kindly/hide-code
+(math/code-detail
+ "code-response-independent-schedule"
+ "Creating a balanced schedule before any responses exist"
+ [:div
+  [:p "Each stratum is shuffled from the explicit seed. A round takes the next item from every queue, records its selection probability, then shuffles those eight items for presentation."]
+  [:pre [:code "(defn selection-schedule [pairs strata-count seed]\n  (let [queues (selection-queues pairs strata-count seed)\n        rounds (apply min (map count queues))]\n    (loop [round-index 0\n           state (normalize-seed (+ seed 104729))\n           result []]\n      (if (= round-index rounds)\n        result\n        (let [selected\n              (mapv (fn [stratum-index queue]\n                      (assoc (nth queue round-index)\n                             :stratum-index stratum-index\n                             :round-index round-index\n                             :selection-probability\n                             (/ 1.0 (- (count queue) round-index))))\n                    (range strata-count) queues)\n              [ordered next-state] (shuffle-vector selected state)]\n          (recur (inc round-index) next-state\n                 (conj result ordered)))))))"]]
+  [:p "Tests assert one item per stratum, no repeats, deterministic replay, and equality when only response data change."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2.cljc"}
+    "View the complete selection schedule"]]])
 ;;
 ;; ### Try one seeded v1/v2 quiz
 
@@ -394,17 +572,25 @@
    [:p "Loading the seeded simulation lab…"]]
   [:noscript "This lab needs JavaScript."]
   [:script#pair-frequency-xs {:type "application/json"}
-   (str "[" (str/join "," fixture-xs) "]")]
-  [:script {:type "application/x-scittle"
-            :src "pair_frequency_logistic_v2.cljc"}]
-  [:script {:type "application/x-scittle"
-            :src "pair_frequency_logistic_v2_interactive.cljs"}]])
+   (str "[" (str/join "," fixture-xs) "]")]])
 
 ;; The browser uses a bounded 41×21 grid and 300 predictive draws so the
 ;; mechanism stays interactive. The authoritative checks and large simulation
 ;; run in CLJ.
 ;;
-;; ## The precommitted promotion gate
+;; ## Simulating a scorer before trusting it
+;;
+;; Simulation makes the hidden truth available because the program creates it.
+;; A **scenario** states how knowledge and measurement are generated. A
+;; **cell** is one exact combination of scenario settings. A **replicate** is
+;; one newly drawn learner-pool under that cell. The **nominal target** is the
+;; cell's intended expected known total before random draws; **realised truth**
+;; is the actual count of the 8,000 latent binary outcomes in one replicate.
+;; They are close on average but need not be equal.
+;;
+;; V1 and v2 receive the same schedule and response prefix in each replicate.
+;; This is a **paired comparison**: differences between scorers are not mixed
+;; with different simulated learners or questions.
 
 ^:kindly/hide-code
 (def tuning-result
@@ -453,6 +639,45 @@
                  (:replicates-per-cell stress-result))
     :rules 1}])
 
+^:kindly/hide-code
+(def gate-inspector-data
+  (let [v1-aggregate (get-in tuning-result [:v1 :aggregate])
+        v2-aggregate (:aggregate tuning-diagnostic-candidate)]
+    {:actual
+     {:aggregate-coverage (* 100.0 (:coverage v2-aggregate))
+      :minimum-cell-coverage (* 100.0
+                                (:minimum-cell-coverage
+                                 tuning-diagnostic-candidate))
+      :aggregate-mae (:mae v2-aggregate)
+      :maximum-cell-mae-ratio (* 100.0
+                                 (:maximum-cell-mae-ratio
+                                  tuning-diagnostic-candidate))
+      :median-items (:median-items v2-aggregate)}
+     :defaults
+     {:aggregate-coverage 94.5
+      :minimum-cell-coverage 94.0
+      :aggregate-mae (/ (double (Math/round (* 10.0 (:mae v1-aggregate))))
+                        10.0)
+      :maximum-cell-mae-ratio 105.0
+      :median-items (:median-items v1-aggregate)}}))
+
+^:kindly/hide-code
+(def gate-inspector-json
+  (let [{actual :actual defaults :defaults} gate-inspector-data]
+    (str
+     "{\"actual\":{"
+     "\"aggregateCoverage\":" (Double/toString (:aggregate-coverage actual)) ","
+     "\"minimumCellCoverage\":" (Double/toString (:minimum-cell-coverage actual)) ","
+     "\"aggregateMae\":" (Double/toString (:aggregate-mae actual)) ","
+     "\"maximumCellMaeRatio\":" (Double/toString (:maximum-cell-mae-ratio actual)) ","
+     "\"medianItems\":" (:median-items actual) "},"
+     "\"defaults\":{"
+     "\"aggregateCoverage\":" (Double/toString (:aggregate-coverage defaults)) ","
+     "\"minimumCellCoverage\":" (Double/toString (:minimum-cell-coverage defaults)) ","
+     "\"aggregateMae\":" (Double/toString (:aggregate-mae defaults)) ","
+     "\"maximumCellMaeRatio\":" (Double/toString (:maximum-cell-mae-ratio defaults)) ","
+     "\"medianItems\":" (:median-items defaults) "}}")))
+
 ;; ### What one simulation replicate did
 ;;
 ;; One replicate represents one possible learner-specific pattern of knowledge
@@ -479,16 +704,31 @@
 ;;    absolute count error, interval width, response log score, and quiz length.
 
 ^:kindly/hide-code
-(kind/mermaid
- "flowchart TD
-    F[Fixed 8,000-pair frequency fixture] --> C[Choose one scenario cell]
-    C --> K[Draw all 8,000 latent known or unknown outcomes]
-    K --> T[Save their sum as the realised truth]
-    K --> R[Reveal scheduled pair responses one balanced round at a time]
-    R --> S[Score the same prefixes with v1 and v2]
-    S --> D[Stop by the candidate rule]
-    T --> M[Measure coverage, error, interval width, log score, and length]
-    D --> M")
+(kind/hiccup
+ [:figure.pf-diagram
+  [:ol.pf-diagram-steps
+   {:role "img"
+    :aria-label "One simulation replicate in six steps. Start with the fixed 8,000-pair fixture and one scenario cell. Draw every latent outcome and save their sum as realised truth. Observe only pairs in the seeded balanced schedule, with declared measurement error if applicable. Score identical response prefixes with v1 and v2. Apply the candidate stopping rule. Compare both results with realised truth using coverage, error, interval width, log score, and quiz length."}
+   [:li [:strong "Fixture + cell"] "Choose target, width, and residual or error condition."]
+   [:li [:strong "Latent pool"] "Draw all 8,000 known-or-unknown outcomes; save their sum as realised truth."]
+   [:li [:strong "Scheduled observations"] "Reveal seeded balanced pairs; apply only the declared measurement error."]
+   [:li [:strong "Paired scoring"] "Give identical response prefixes to v1 and v2."]
+   [:li [:strong "Stopping"] "Apply the same candidate rule at complete rounds."]
+   [:li [:strong "Metrics"] "Compare intervals, errors, log scores, and lengths with realised truth."]]
+  [:figcaption.pf-caption
+   "The latent total and the observed response stream are separate. Pairing keeps scorer comparisons on the same simulated learner and schedule."]])
+
+^:kindly/hide-code
+(math/code-detail
+ "code-simulated-replicate"
+ "Generating one complete latent learner-pool and its measured responses"
+ [:div
+  [:p "The runner first draws every latent pair outcome and saves their sum. Only then does it look up the scheduled pair indexes and optionally flip measured outcomes."]
+  [:pre [:code "(defn simulate-replicate\n  [xs selected\n   {:keys [threshold residual-sd false-positive false-negative\n           rank-error-maximum]\n    :or {false-positive 0.0 false-negative 0.0\n         rank-error-maximum 0.0}\n    :as scenario}\n   seed]\n  (let [rng (Random. (long seed))\n        known (byte-array pool-size)\n        true-total\n        (loop [index 0 total 0]\n          (if (= index pool-size)\n            total\n            (let [residual (if (zero? residual-sd)\n                             0.0\n                             (* residual-sd (.nextGaussian rng)))\n                  probability\n                  (latent-probability (nth xs index) scenario\n                                      threshold residual)\n                  outcome (if (< (.nextDouble rng) probability) 1 0)]\n              (aset-byte known index (byte outcome))\n              (recur (inc index) (+ total outcome)))))\n        responses (byte-array maximum-items)]\n    (dotimes [index maximum-items]\n      (let [pair-index (:pair-index (nth selected index))\n            known? (= 1 (aget known pair-index))\n            rank-error (* rank-error-maximum (/ pair-index 7999.0))]\n        (aset-byte responses index\n                   (byte (measured-outcome\n                          rng known?\n                          (+ false-positive rank-error)\n                          (+ false-negative rank-error))))))\n    {:truth true-total :responses responses}))"]]
+  [:p "The first loop materialises all 8,000 latent outcomes. The second observes only the fixed schedule and applies any declared measurement-error mechanism."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_gate.clj"}
+    "View the complete replicate generator"]]])
 
 ;; Within a phase, one seeded 160-item schedule was reused for every cell and
 ;; replicate. This paired the model comparisons and made the run deterministic.
@@ -530,6 +770,117 @@
 ;; heterogeneity. It is not a persistent item calibration effect shared across
 ;; simulated learners.
 ;;
+;; ### Three separated phases
+;;
+;; **Tuning** searches choices using one dataset. A **held-out evaluation** uses
+;; fresh data and a different seed after choices are frozen. A **stress test**
+;; deliberately generates conditions outside the candidate model. Reusing the
+;; tuning seed or feeding diagnostic results back into the rule would erase
+;; that separation.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:figure.pf-diagram
+  [:div.pf-phase-diagram
+   {:role "img"
+    :aria-label "Three separated simulation phases. Tuning uses seed 2026071301, 45 cells, 500 replicates per cell, and evaluates 100 rules against five checks. No rule passes, so the diagnostic candidate is frozen. It then goes separately to a held-out supported diagnostic with seed 2026071302, 45 cells and 2,000 replicates per cell, and to an untuned stress diagnostic with seed 2026071305, 60 cells and 2,000 replicates per cell. Neither diagnostic feeds back into tuning."}
+   [:div.pf-phase-node
+    [:strong "1 · Tuning"]
+    "45 cells × 500 · seed 2026071301"
+    [:br]
+    "Evaluate 100 rules against all five checks."]
+   [:div.pf-arrow {:aria-hidden "true"} "→"]
+   [:div.pf-phase-branch
+    [:div.pf-phase-node
+     [:strong "2 · Freeze"]
+     "No rule passed. Freeze one diagnostic candidate; do not promote."]
+    [:div.pf-phase-node
+     [:strong "3a · Held-out"]
+     "45 cells × 2,000 · seed 2026071302 · diagnosis only."]
+    [:div.pf-phase-node
+     [:strong "3b · Stress"]
+     "60 cells × 2,000 · seed 2026071305 · diagnosis only."]]]
+  [:figcaption.pf-caption
+   "Separate data and seeds preserve the direction of learning: tuning may choose what to inspect; diagnostics never rewrite tuning."]])
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.pf-table-wrap
+  [:table.pf-table
+   [:caption.pf-sr-only "Simulation phases and replicate counts"]
+   [:thead
+    [:tr [:th {:scope "col"} "Phase"]
+     [:th {:scope "col"} "Cells"]
+     [:th {:scope "col"} "Replicates / cell"]
+     [:th {:scope "col"} "Simulated learner-pools"]
+     [:th {:scope "col"} "Rules scored"]]]
+   [:tbody
+    (for [{:keys [phase cells replicates learners rules]} simulation-phases]
+      [:tr {:key phase}
+       [:th {:scope "row"} phase]
+       [:td cells]
+       [:td (format "%,d" replicates)]
+       [:td (format "%,d" learners)]
+       [:td rules]])
+    [:tr
+     [:th {:scope "row"} "Total"]
+     [:td "150 cell-phases"]
+     [:td "—"]
+     [:td (format "%,d" (reduce + (map :learners simulation-phases)))]
+     [:td "—"]]]]])
+
+;; The 500-replicate tuning run generated 22,500 independent learner-pool
+;; realisations—not 2.25 million. The same 22,500 response streams were rescored
+;; under all 100 rules. Across the three phases the immutable artifacts record
+;; 232,500 simulated learner-pools.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-read-edn-artifacts"
+ "Reading immutable simulation-result artifacts at render time"
+ [:div
+  [:p "The article does not rerun 232,500 learner-pools during publication. It reads frozen EDN data produced by the separately seeded validation runs."]
+  [:pre [:code "(def tuning-result\n  (edn/read-string\n   (slurp (io/resource\n           \"language_learning/vocabulary_estimation/\n            pair_frequency_logistic_v2_tuning.edn\"))))"]]
+  [:p "The rendered tables, gate inspector payload, assertions, fixture ID, hash, seeds, and numerical-method record all come from those versioned resources."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/tree/main/resources/language_learning/vocabulary_estimation"}
+    "View the immutable EDN artifacts"]]])
+;;
+;; ### Metrics: what counted as better?
+;;
+;; **Coverage** is the fraction of repeated 95% intervals containing the
+;; replicate's realised truth. **Calibration** means those intervals achieve
+;; their stated long-run coverage under the tested scenario; it does not mean
+;; every individual interval contains truth. **Bias** is mean signed error:
+;; estimate minus truth. **Mean absolute error (MAE)** ignores direction and
+;; averages the size of the count error.
+;;
+;; **Response log score** rewards probability assigned to the response that
+;; occurred; larger (less negative) is better. It tests response prediction,
+;; not count calibration by itself. **Quiz length** is the number of administered
+;; items at stopping. **Monte Carlo standard error (MCSE)** describes noise from
+;; a finite number of simulation replicates. For estimated coverage $\hat p$
+;; from $n$ independent replicates:
+;;
+;; $$\operatorname{MCSE}(\hat p)\approx
+;; \sqrt{\frac{\hat p(1-\hat p)}{n}}.$$
+
+^:kindly/hide-code
+(math/explanation
+ "math-coverage-mcse"
+ "Monte Carlo uncertainty in an estimated coverage proportion"
+ [["p̂" "The observed fraction of simulated intervals containing realised truth."]
+  ["n" "The number of independent replicates in the cell."]
+  ["p̂(1−p̂)" "The Bernoulli variance implied by the observed coverage."]
+  ["square root" "Converts the variance of the estimated fraction into a standard error."]]
+ "MCSE measures simulation noise, not uncertainty about whether the simulated scenarios resemble real learners.")
+;;
+;; ## Precommitment: choose rules before results
+;;
+;; **Precommitment** means declaring candidate rules, metrics, thresholds, and
+;; the all-checks-must-pass logic before seeing their results. It prevents a
+;; near miss from becoming a pass by moving the finish line afterwards.
+;;
 ;; ### How stopping rules were tuned
 ;;
 ;; The search crossed minimum lengths `24`, `32`, `40`, and `48`; interval
@@ -537,6 +888,18 @@
 ;; soft caps `64`, `80`, `96`, `128`, and `160`. This produced 100 valid rules.
 ;; A rule stopped at the first complete-round checkpoint at which its width
 ;; target was met, or at its cap.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-stopping-rule-predicate"
+ "Applying one candidate stopping rule at complete rounds"
+ [:div
+  [:p "Starting at the rule's minimum, the runner checks eight-item boundaries until precision is reached or the soft cap is reached."]
+  [:pre [:code "(let [precision?\n      (<= (/ (- upper lower) 2.0)\n          (* target-half-width-ratio pool-size))\n      soft-maximum?\n      (>= items-tested soft-maximum-items)]\n  (if (or precision? soft-maximum?)\n    {:items-tested items-tested\n     :stopping-reason\n     (if precision? :precision-target :soft-maximum)}\n    (recur (+ items-tested strata-count))))"]]
+  [:p "The 100 rules change only minimum, target half-width, and cap; the balanced schedule and scorers remain fixed."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_gate.clj"}
+    "View the stopping rule search"]]])
 ;;
 ;; Each rule had to pass all five checks below. Aggregate checks prevent a noisy
 ;; single cell from dominating; cellwise checks prevent good averages from
@@ -569,40 +932,19 @@
      [:td "No longer than v1"]
      [:td "Do not require more answers for the gain"]]]]])
 
-;; The 500-replicate tuning run therefore generated 22,500 independent
-;; learner-pool realisations—not 2.25 million. The same 22,500 response streams
-;; were rescored under all 100 rules, which makes rule comparisons paired.
-
 ^:kindly/hide-code
-(kind/hiccup
- [:div.pf-table-wrap
-  [:table.pf-table
-   [:caption.pf-sr-only "Simulation phases and replicate counts"]
-   [:thead
-    [:tr [:th {:scope "col"} "Phase"]
-     [:th {:scope "col"} "Cells"]
-     [:th {:scope "col"} "Replicates / cell"]
-     [:th {:scope "col"} "Simulated learner-pools"]
-     [:th {:scope "col"} "Rules scored"]]]
-   [:tbody
-    (for [{:keys [phase cells replicates learners rules]} simulation-phases]
-      [:tr {:key phase}
-       [:th {:scope "row"} phase]
-       [:td cells]
-       [:td (format "%,d" replicates)]
-       [:td (format "%,d" learners)]
-       [:td rules]])
-    [:tr
-     [:th {:scope "row"} "Total"]
-     [:td "150 cell-phases"]
-     [:td "—"]
-     [:td (format "%,d" (reduce + (map :learners simulation-phases)))]
-     [:td "—"]]]]])
+(math/code-detail
+ "code-five-part-gate"
+ "Requiring all five promotion checks with logical AND"
+ [:div
+  [:p "The aggregate and cellwise checks are evaluated together. Clojure's and returns true only when every clause is true."]
+  [:pre [:code "(and (>= (:coverage aggregate) 0.945)\n     (every? #(>= (:coverage %) 0.94) cells)\n     (< (:mae aggregate) (:mae v1-aggregate))\n     (every? true?\n             (map #(<= (:mae %1) (* 1.05 (:mae %2)))\n                  cells v1-cells))\n     (<= (:median-items aggregate)\n         (:median-items v1-aggregate)))"]]
+  [:p "There is no score, majority vote, or discretionary override. One false clause prevents promotion."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_gate.clj"}
+    "View the gate calculation"]]])
 
-;; The stress phase was diagnostic only. The promotion decision had already
-;; failed in tuning; neither held-out nor stress results were used to retune v2.
-;;
-;; ### What tuning selected for diagnosis
+;; ## Gate result: no rule passed
 ;;
 ;; No rule satisfied all five checks. The rule with the best worst-cell
 ;; coverage started at 48 items, targeted a 7.5%-of-pool half-width, and capped
@@ -610,6 +952,45 @@
 ;; worst cell covered only 92.4%, its worst cell's MAE was 22.0% above v1, and
 ;; its median length was 64 rather than v1's 40. It was therefore not eligible
 ;; for promotion.
+
+^:kindly/hide-code
+(math/code-detail
+ "code-passing-rule-selection"
+ "Selecting only among rules that already passed"
+ [:div
+  [:p "Selection first filters to passes? rules, then prefers the shortest by median and mean length with deterministic tie-breakers. With no passes, it returns nil."]
+  [:pre [:code "(defn choose-rule [tuning]\n  (first\n   (sort-by\n    (juxt #(get-in % [:aggregate :median-items])\n          #(get-in % [:aggregate :mean-items])\n          #(get-in % [:rule :minimum-items])\n          #(get-in % [:rule :soft-maximum-items])\n          #(get-in % [:rule :target-half-width-ratio]))\n    (filter :passes? (:rules tuning)))))\n\n;; Historical result:\n(choose-rule tuning-result) ;=> nil"]]
+  [:p "The best-worst-coverage rule was chosen only for diagnosis after the promotion gate had failed; it was never relabelled as a winner."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_gate.clj"}
+    "View passing-rule selection and its tests"]]])
+
+;; ### Inspect the historical gate
+;;
+;; The five actual values below come from the immutable tuning artifact. Moving
+;; a slider asks a counterfactual question only: “What if the threshold had been
+;; different?” It never edits the EDN file, reruns the simulation, or changes
+;; the recorded non-promotion decision. Reset restores the precommitted gate.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:div.pf-lab
+  [:div#pair-frequency-gate-inspector
+   [:p "Loading the gate inspector…"]]
+  [:noscript "This inspector needs JavaScript."]
+  [:script#pair-frequency-gate-data {:type "application/json"}
+   gate-inspector-json]
+  [:script {:type "application/x-scittle"
+            :src "pair_frequency_logistic_v2.cljc"}]
+  [:script {:type "application/x-scittle"
+            :src "pair_frequency_logistic_v2_interactive.cljs"}]])
+;;
+;; At the historical defaults, only aggregate coverage and aggregate MAE pass.
+;; Worst-cell coverage, worst-cell MAE ratio, and median length fail. The
+;; overall decision is therefore **not promoted**: two passes out of five are
+;; not enough, and even four would not have been enough.
+;;
+;; ## Held-out diagnosis after the failed gate
 ;;
 ;; Because there was no eligible rule, the 2,000-replicate-per-cell run below is
 ;; a **held-out diagnostic**, not a promotion gate. Following the declared
@@ -670,6 +1051,18 @@
  [:div.pf-callout.provisional
   [:strong "Large-run numerical shortcut"]
   "The CLJ gate runner integrates parameter uncertainty on the full 161×81 grid, then uses 512 deterministic systematic grid samples and a moment-matched normal approximation to each untested Poisson-binomial total. The exact finite-pool scorer above performs pair-level Bernoulli simulation. The shortcut is recorded in the result artifact and is another reason not to promote a near-miss."])
+
+^:kindly/hide-code
+(math/code-detail
+ "code-recorded-numerical-shortcut"
+ "Recording the large-run approximation and refusing to excuse a near miss"
+ [:div
+  [:p "Every result artifact names the approximation and draw count, so a future rerun can reproduce or replace it without pretending the computation was exact."]
+  [:pre [:code ":interval-method\n{:parameter-mixture :deterministic-systematic-grid-sampling\n :untested-pair-total :moment-matched-poisson-binomial-normal\n :draws 512}"]]
+  [:p "The shortcut was declared and recorded, but it was not validated tightly enough to rescue a failed cell. A candidate near a threshold needs stronger numerical evidence, not a post-hoc waiver."]
+  [:p.article-code-source
+   [:a {:href "https://github.com/ClojureCivitas/clojurecivitas.github.io/blob/main/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_gate.clj"}
+    "View the deterministic mixture interval and artifact metadata"]]])
 
 ;; Aggregate v2 coverage and MAE improved substantially, but the gate protects
 ;; against hiding weak cells in an average. Worst-cell coverage was `91.95%`,
@@ -775,7 +1168,52 @@
 ;; therefore reinforce the non-promotion decision; they were not used to revise
 ;; the rule.
 ;;
-;; ## What was learned
+;; ## Model validation is not a software build
+;;
+;; The **model-validation gate** asks whether simulated measurement performance
+;; justifies promotion. An **automated test** asks whether code still behaves as
+;; specified; Clojure's `clojure.test` framework records such assertions. A
+;; **targeted render** rebuilds only this article for fast review. The
+;; **full-site publication gate** renders the complete site immediately before
+;; publishing, catching cross-page and shared-configuration failures. These are
+;; different forms of evidence: perfect software tests cannot turn a failed
+;; coverage check into a pass.
+;;
+;; The executable source is evaluated by
+;; [Clay](https://scicloj.github.io/clay/), which emits the article input;
+;; [Quarto](https://quarto.org/docs/cli/render.html) renders one page or a whole
+;; project; and [Scittle](https://github.com/babashka/scittle) runs the bounded
+;; ClojureScript interactions in the browser. The CLJ and CLJS suites check
+;; parity and deterministic replay before visual checks cover controls,
+;; accessibility, responsive layout, themes, and console errors.
+
+^:kindly/hide-code
+(kind/hiccup
+ [:figure.pf-diagram
+  [:div.pf-workflow-lanes
+   {:role "img"
+    :aria-label "Two evidence lanes meet at a versioned publication decision. The model lane moves from immutable fixture and seeded artifacts through the five-part validation gate to either promotion if every check passes or non-promotion if any check fails. The software lane moves from Clojure and ClojureScript source through automated tests, targeted rendering, separate-tab browser checks, and the full-site publication gate. Software success cannot override model-gate failure."}
+   [:section.pf-lane
+    [:h3 "Model evidence"]
+    [:ol.pf-diagram-steps
+     [:li [:strong "Versioned evidence"] "Immutable fixture, seeds, scenarios, and result artifacts."]
+     [:li [:strong "Validation gate"] "Coverage, MAE, and length; all five checks required."]
+     [:li [:strong "Decision"] "Promote only if all pass; otherwise retain v1."]]]
+   [:section.pf-lane
+    [:h3 "Software and publication evidence"]
+    [:ol.pf-diagram-steps
+     [:li [:strong "Automated tests"] "CLJ, CLJS, parity, and executable assertions."]
+     [:li [:strong "Targeted render"] "Clay and Quarto rebuild the affected article."]
+     [:li [:strong "Browser checks"] "Controls, console, layout, themes, and accessibility in a separate tab."]
+     [:li [:strong "Publication gate"] "Render the full site immediately before push."]]]]
+  [:figcaption.pf-caption
+   "Both lanes must be trustworthy, but they answer different questions. Passing software checks cannot override failed model evidence."]])
+;;
+;; A later promoted scorer would still retain its versioned predecessor so a
+;; **rollback** could restore the earlier target without rewriting old events or
+;; articles. Here no rollback is needed: v2 never replaced v1.
+;;
+;; ## What was learned—and what comes next
 ;;
 ;; 1. Replacing eight independent rates with one continuous curve greatly
 ;;    improves aggregate MAE and response log score under related simulations.
@@ -787,8 +1225,22 @@
 ;;
 ;; `continuous-pair-frequency-logistic-v2` remains an experimental, replayable
 ;; checkpoint. The current target stays `stratified-beta-binomial-v1`.
+;;
+;; The next article will define and version how self-reported CEFR chooses a
+;; lemma–surface-form-pair pool. Later articles will consider correlated form
+;; pairs through latent lemma knowledge; model correct, wrong, and don't-know
+;; separately with guessing and slips; calibrate complete item versions before
+;; evaluating IRT and adaptive selection; and investigate multiple contexts or
+;; senses only if stable sense identifiers and repeated observations make them
+;; identifiable. Those are previews, not features silently added to v2.
 
 ^:kindly/hide-code
+(kind/hiccup
+ [:div.article-recap
+  [:strong "Decision"]
+  [:p "Pair frequency was useful enough to study further, but this continuous v2 scorer did not earn promotion. The gate stayed fixed, the negative result stayed visible, and v1 remained the target."]])
+
+^{:kindly/hide-code true :kindly/kind :kind/hidden}
 (do
   (assert (= 8000 (count fixture-pairs)))
   (assert (= [0.5 0.1 0.9]
@@ -800,9 +1252,19 @@
   (assert (empty? (filter :passes? (:rules tuning-result))))
   (assert (= tuning-diagnostic-candidate
              (apply max-key :minimum-cell-coverage (:rules tuning-result))))
+  (assert (= 0.9548444444444445
+             (get-in tuning-diagnostic-candidate [:aggregate :coverage])))
+  (assert (= 0.924 (:minimum-cell-coverage tuning-diagnostic-candidate)))
+  (assert (= 253.03401249924173
+             (get-in tuning-diagnostic-candidate [:aggregate :mae])))
+  (assert (= 1.2204936105432285
+             (:maximum-cell-mae-ratio tuning-diagnostic-candidate)))
+  (assert (= 64 (get-in tuning-diagnostic-candidate
+                        [:aggregate :median-items])))
+  (assert (= 610.7162847330441 (get-in tuning-result [:v1 :aggregate :mae])))
+  (assert (= 40 (get-in tuning-result [:v1 :aggregate :median-items])))
   (assert (= 232500 (reduce + (map :learners simulation-phases))))
   (assert (not (:passes? held-out-candidate)))
   (assert (= 1839 (long (* (:replicates-per-cell held-out-result)
                            (:minimum-cell-coverage held-out-candidate)))))
-  (assert (= 60 (:stress-cell-count stress-result)))
-  :verified-negative-result)
+  (assert (= 60 (:stress-cell-count stress-result))))

--- a/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_interactive.cljs
@@ -57,6 +57,9 @@
         [:g [:line {:x1 41 :x2 48 :y1 y :y2 y :stroke "currentColor"}]
          [:text {:x 35 :y (+ y 5) :text-anchor "end" :font-size 13
                  :fill "currentColor"} label]])
+      [:text {:x 14 :y 130 :text-anchor "middle" :font-size 14
+              :transform "rotate(-90 14 130)" :fill "currentColor"}
+       "Knowing probability pᵢ"]
       [:path {:d (curve-path threshold width) :fill "none" :stroke "#2780e3"
               :stroke-width 4 :vector-effect "non-scaling-stroke"}]
       [:text {:x 343 :y 250 :text-anchor "middle" :font-size 14

--- a/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_interactive.cljs
+++ b/src/language_learning/vocabulary_estimation/pair_frequency_logistic_v2_interactive.cljs
@@ -3,10 +3,13 @@
             [reagent.core :as r]
             [reagent.dom :as rdom]))
 
-(def xs
-  (js->clj
-   (js/JSON.parse
-    (.-textContent (.getElementById js/document "pair-frequency-xs")))))
+(defn parse-json-element [id keywordize?]
+  (when-let [element (.getElementById js/document id)]
+    (js->clj (js/JSON.parse (.-textContent element))
+             :keywordize-keys keywordize?)))
+
+(def xs (or (parse-json-element "pair-frequency-xs" false) []))
+(def gate-data (parse-json-element "pair-frequency-gate-data" true))
 
 (def number-format (js/Intl.NumberFormat. "en-US"))
 (defn format-count [number] (.format number-format (js/Math.round number)))
@@ -14,25 +17,36 @@
 
 (defonce curve-state (r/atom {:threshold 0.0 :width 2.0}))
 
+(def curve-x-min -1.2)
+(def curve-x-max 7.2)
+(defn curve-px [x]
+  (+ 48 (* (- x curve-x-min) (/ 590.0 (- curve-x-max curve-x-min)))))
+
 (defn curve-path [threshold width]
   (->> (range 101)
        (map (fn [index]
-              (let [x (+ -1.2 (* index (/ 8.4 100.0)))
+              (let [x (+ curve-x-min
+                         (* index (/ (- curve-x-max curve-x-min) 100.0)))
                     probability (v2/knowledge-probability x threshold width)
-                    px (+ 48 (* index 5.9))
+                    px (curve-px x)
                     py (- 210 (* probability 160))]
                 (str (if (zero? index) "M" "L") px " " py))))
        (clojure.string/join " ")))
 
-(defn field [id label value minimum maximum step on-change]
+(defn field [id label value minimum maximum step on-input]
   [:div.pf-control
    [:label {:for id} label ": " [:strong (.toFixed value 2)]]
    [:input {:id id :type "range" :value value :min minimum :max maximum
-            :step step :on-change on-change}]])
+            :step step :on-input on-input :on-change on-input}]])
 
 (defn curve-explorer []
   (let [{:keys [threshold width]} @curve-state
-        total (v2/expected-total xs threshold width)]
+        total (v2/expected-total xs threshold width)
+        anchors [{:x (- threshold (/ width 2.0))
+                  :probability 0.1 :label "10%, odds 1 to 9"}
+                 {:x threshold :probability 0.5 :label "50%, odds 1 to 1"}
+                 {:x (+ threshold (/ width 2.0))
+                  :probability 0.9 :label "90%, odds 9 to 1"}]]
     [:div
      [:div.pf-controls
       [field "curve-threshold" "Threshold t" threshold -2.5 3.0 0.05
@@ -42,13 +56,16 @@
      [:p.pf-live {:aria-live "polite"}
       "Expected known total in this fixture: " [:strong (format-count total)]
       " of 8,000 pairs."]
+     [:p.pf-note
+      "Annotated dots mark t − w/2 (10%), t (50%), and t + w/2 (90%) when those positions are inside the displayed predictor range."]
      [:svg {:view-box "0 0 680 270" :role "img"
             :aria-labelledby "curve-title curve-desc"}
       [:title#curve-title "Frequency predictor and knowing probability"]
       [:desc#curve-desc
        (str "A logistic curve with threshold " (.toFixed threshold 2)
             ", width " (.toFixed width 2) ", and expected total "
-            (format-count total) ".")]
+            (format-count total)
+            ". Dots identify the ten, fifty, and ninety percent anchor points when visible.")]
       [:line {:x1 48 :x2 638 :y1 210 :y2 210 :stroke "currentColor"}]
       [:line {:x1 48 :x2 48 :y1 50 :y2 210 :stroke "currentColor"}]
       (for [[probability label] [[0 "0"] [0.5 ".5"] [1 "1"]]
@@ -60,8 +77,22 @@
       [:text {:x 14 :y 130 :text-anchor "middle" :font-size 14
               :transform "rotate(-90 14 130)" :fill "currentColor"}
        "Knowing probability pᵢ"]
-      [:path {:d (curve-path threshold width) :fill "none" :stroke "#2780e3"
+      [:path {:d (curve-path threshold width) :fill "none"
+              :stroke "var(--pf-accent,#2780e3)"
               :stroke-width 4 :vector-effect "non-scaling-stroke"}]
+      (for [{:keys [x probability label]} anchors
+            :when (<= curve-x-min x curve-x-max)
+            :let [px (curve-px x)
+                  py (- 210 (* probability 160))]]
+        ^{:key label}
+        [:g
+         [:line {:x1 px :x2 px :y1 py :y2 210
+                 :stroke "var(--pf-warn,#8a5000)"
+                 :stroke-width 1.5 :stroke-dasharray "4 4"}]
+         [:circle {:cx px :cy py :r 6
+                   :fill "var(--pf-warn,#8a5000)"
+                   :stroke "var(--bs-body-bg,#fff)" :stroke-width 2}
+          [:title label]]])
       [:text {:x 343 :y 250 :text-anchor "middle" :font-size 14
               :fill "currentColor"} "Standardized log₁₀ pair frequency x"]]]))
 
@@ -72,6 +103,102 @@
 (defonce lab-state
   (r/atom {:seed 20260713 :threshold -0.19 :width 1.5
            :status :idle :result nil}))
+
+(def response-demo-sequence
+  [:correct :wrong :dont-know :correct :correct :dont-know :wrong :correct
+   :dont-know :correct :wrong :wrong :correct :dont-know :correct :correct])
+
+(def response-demo-limit 16)
+(defonce response-demo-state (r/atom {:revealed 0}))
+
+(defn response-demo-label [response]
+  (case response
+    :correct "correct"
+    :wrong "wrong"
+    :dont-know "don't know"
+    "none"))
+
+(defn response-demo-item [index]
+  (let [stratum (inc (mod index 8))
+        round (inc (quot index 8))]
+    {:stratum stratum
+     :round round
+     :item-id (str "S" stratum "-R" round)
+     :response (nth response-demo-sequence index)}))
+
+(defn reveal-response-demo! []
+  (swap! response-demo-state update :revealed
+         #(min response-demo-limit (inc %))))
+
+(defn reset-response-demo! []
+  (reset! response-demo-state {:revealed 0}))
+
+(defn response-inference-simulator []
+  (let [revealed (:revealed @response-demo-state)
+        selections (mapv response-demo-item (range revealed))
+        latest (peek selections)
+        correct (count (filter #(= :correct (:response %)) selections))
+        not-correct (- revealed correct)
+        next-selection (when (< revealed response-demo-limit)
+                         (response-demo-item revealed))
+        complete? (= revealed response-demo-limit)]
+    [:section.pf-response-shell
+     {:aria-labelledby "response-inference-heading"}
+     [:h3#response-inference-heading "Responses update inference, not selection"]
+     [:p
+      "As in article 1, two demonstration rounds are queued before any answer. Reveal the same fixed schedule while watching only the inference state change."]
+     [:div.pf-response-grid
+      (for [stratum (range 1 9)
+            :let [seen (filterv #(= stratum (:stratum %)) selections)
+                  most-recent (peek seen)
+                  next-round (inc (count seen))]]
+        ^{:key stratum}
+        [:div.pf-response-card
+         [:strong (str "Stratum " stratum)]
+         [:span (if most-recent
+                  (str "Latest: " (:item-id most-recent)
+                       " · " (response-demo-label (:response most-recent)))
+                  "Latest: none")]
+         [:small (if (< next-round 3)
+                   (str "Next queued: S" stratum "-R" next-round)
+                   "Two demonstration items used")]])]
+     [:progress.pf-response-progress
+      {:value revealed :max response-demo-limit
+       :aria-label "Scheduled demonstration items revealed"}]
+     [:div.pf-response-effects
+      [:div.pf-response-effect
+       [:strong "Inference changes"]
+       [:span (if (zero? revealed)
+                "Posterior still equals the prior"
+                (str revealed " response term" (when (not= revealed 1) "s")
+                     ": " correct " correct · " not-correct " not correct"))]
+       [:small (if latest
+                 (str "Latest likelihood contribution: "
+                      (if (= :correct (:response latest)) "pᵢ" "1 − pᵢ"))
+                 "Each response will reweight the posterior.")]]
+      [:div.pf-response-effect.is-fixed
+       [:strong "Selection stays fixed"]
+       [:span (if next-selection
+                (str "Next scheduled: " (:item-id next-selection))
+                "Both fixed rounds complete")]
+       [:small "No response changes an item queue."]]]
+     [:p.pf-response-status
+      {:aria-live "polite"}
+      (cond
+        complete? "Two complete rounds. Inference used all 16 responses; every queue followed its original order."
+        latest (str "Recorded " (:item-id latest) " as "
+                    (response-demo-label (:response latest))
+                    ". The posterior changed; the next scheduled item did not.")
+        :else "Ready. The eight queues and both rounds already exist.")]
+     [:div.pf-response-actions
+      [:button.pf-response-button.is-primary
+       {:type "button" :on-click reveal-response-demo! :disabled complete?}
+       (if complete? "Two rounds complete" "Reveal next scheduled item")]
+      [:button.pf-response-button
+       {:type "button" :on-click reset-response-demo!}
+       "Reset"]]
+     [:p.pf-note
+      "The response labels are illustrative. The schedule is S1 through S8 in both rounds, independent of every answer."]]))
 
 (defn browser-pairs []
   (mapv (fn [index]
@@ -167,8 +294,8 @@
            (format-count (:upper v2)) ")")]]]
    [:svg {:view-box "0 0 680 135" :role "img"
           :aria-label "v1 and bounded v2 estimates with 95 percent intervals"}
-    [interval-row "v1" "#7b61a8" v1]
-    [interval-row "v2" "#2780e3" v2]
+    [interval-row "v1" "var(--pf-warn,#8a5000)" v1]
+    [interval-row "v2" "var(--pf-accent,#1464b5)" v2]
     [:line {:x1 40 :x2 640 :y1 116 :y2 116 :stroke "currentColor"}]
     (for [value [0 2000 4000 6000 8000]
           :let [x (+ 40 (* value (/ 600 8000.0)))]]
@@ -201,14 +328,181 @@
         :error [:p {:role "alert"} (str "Simulation failed: " error)]
         [:p "Choose parameters, then run the quiz."])]]))
 
+(def gate-defaults
+  (or (:defaults gate-data)
+      {:aggregateCoverage 94.5
+       :minimumCellCoverage 94.0
+       :aggregateMae 610.7
+       :maximumCellMaeRatio 105.0
+       :medianItems 40}))
+
+(def gate-actual
+  (or (:actual gate-data)
+      {:aggregateCoverage 95.484
+       :minimumCellCoverage 92.4
+       :aggregateMae 253.0
+       :maximumCellMaeRatio 122.05
+       :medianItems 64}))
+
+(defonce gate-state (r/atom gate-defaults))
+
+(def gate-threshold-specs
+  [{:key :aggregateCoverage
+    :id "gate-aggregate-coverage"
+    :label "Minimum aggregate coverage"
+    :minimum 90.0 :maximum 99.5 :step 0.1 :suffix "%"}
+   {:key :minimumCellCoverage
+    :id "gate-worst-cell-coverage"
+    :label "Minimum worst-cell coverage"
+    :minimum 88.0 :maximum 99.5 :step 0.1 :suffix "%"}
+   {:key :aggregateMae
+    :id "gate-aggregate-mae"
+    :label "Maximum aggregate MAE"
+    :minimum 200.0 :maximum 800.0 :step 0.1 :suffix " pairs"}
+   {:key :maximumCellMaeRatio
+    :id "gate-worst-cell-mae-ratio"
+    :label "Maximum worst-cell MAE ratio"
+    :minimum 95.0 :maximum 140.0 :step 0.5 :suffix "%"}
+   {:key :medianItems
+    :id "gate-median-items"
+    :label "Maximum median quiz length"
+    :minimum 24 :maximum 96 :step 8 :suffix " items"}])
+
+(defn fixed [value digits]
+  (.toFixed (js/Number value) digits))
+
+(defn threshold-label [key value]
+  (case key
+    :aggregateCoverage (str (fixed value 1) "%")
+    :minimumCellCoverage (str (fixed value 1) "%")
+    :aggregateMae (str (fixed value 1) " pairs")
+    :maximumCellMaeRatio (str (fixed value 1) "%")
+    :medianItems (str (js/Math.round value) " items")))
+
+(defn gate-checks [thresholds]
+  (let [{:keys [aggregateCoverage minimumCellCoverage aggregateMae
+                maximumCellMaeRatio medianItems]} gate-actual]
+    [{:key :aggregateCoverage
+      :label "Aggregate interval coverage"
+      :comparison (str (fixed aggregateCoverage 3) "% ≥ "
+                       (fixed (:aggregateCoverage thresholds) 1) "%")
+      :passes? (>= aggregateCoverage (:aggregateCoverage thresholds))}
+     {:key :minimumCellCoverage
+      :label "Worst-cell interval coverage"
+      :comparison (str (fixed minimumCellCoverage 1) "% ≥ "
+                       (fixed (:minimumCellCoverage thresholds) 1) "%")
+      :passes? (>= minimumCellCoverage (:minimumCellCoverage thresholds))}
+     {:key :aggregateMae
+      :label "Aggregate MAE"
+      :comparison (str (fixed aggregateMae 1) " < "
+                       (fixed (:aggregateMae thresholds) 1))
+      :passes? (< aggregateMae (:aggregateMae thresholds))}
+     {:key :maximumCellMaeRatio
+      :label "Worst-cell v2/v1 MAE ratio"
+      :comparison (str (fixed maximumCellMaeRatio 2) "% ≤ "
+                       (fixed (:maximumCellMaeRatio thresholds) 1) "%")
+      :passes? (<= maximumCellMaeRatio
+                   (:maximumCellMaeRatio thresholds))}
+     {:key :medianItems
+      :label "Median quiz length"
+      :comparison (str (js/Math.round medianItems) " ≤ "
+                       (js/Math.round (:medianItems thresholds)))
+      :passes? (<= medianItems (:medianItems thresholds))}]))
+
+(defn gate-threshold-field
+  [{:keys [key id label minimum maximum step]} thresholds]
+  (let [value (get thresholds key)]
+    [:div.pf-gate-field
+     [:div
+      [:label {:for id} label]
+      [:output {:for id} (threshold-label key value)]]
+     [:input {:id id :type "range" :value value
+              :min minimum :max maximum :step step
+              :aria-describedby "gate-counterfactual-note"
+              :on-input #(swap! gate-state assoc key (parse-number %))
+              :on-change #(swap! gate-state assoc key (parse-number %))}]]))
+
+(defn reset-gate! []
+  (reset! gate-state gate-defaults))
+
+(defn gate-inspector []
+  (let [thresholds @gate-state
+        checks (gate-checks thresholds)
+        passing-count (count (filter :passes? checks))
+        all-pass? (= passing-count (count checks))
+        counterfactual? (not= thresholds gate-defaults)]
+    [:section.pf-gate-shell {:aria-labelledby "gate-inspector-heading"}
+     [:h3#gate-inspector-heading "Five checks, one AND decision"]
+     [:div {:class (str "pf-gate-banner "
+                        (if counterfactual?
+                          "is-counterfactual"
+                          "is-historical"))
+            :aria-live "polite"}
+      [:strong
+       (if counterfactual?
+         "COUNTERFACTUAL THRESHOLDS — teaching only"
+         "Historical precommitted gate")]
+      [:span
+       (if counterfactual?
+         (str (if all-pass?
+                "Would promote under these altered thresholds"
+                "Would not promote under these altered thresholds")
+              " · " passing-count "/5 checks pass.")
+         (str "NOT PROMOTED · " passing-count "/5 checks passed."))]]
+     [:p#gate-counterfactual-note.pf-note
+      (if counterfactual?
+        "These sliders do not edit the immutable results or revise the historical non-promotion decision."
+        "Defaults reproduce the historical tuning gate. Promotion requires all five checks.")]
+     [:div.pf-gate-controls
+      (for [spec gate-threshold-specs]
+        ^{:key (:key spec)}
+        [gate-threshold-field spec thresholds])]
+     [:div.pf-table-wrap
+      [:table.pf-table.pf-gate-table
+       [:caption.pf-sr-only "Gate checks under the currently displayed thresholds"]
+       [:thead
+        [:tr
+         [:th {:scope "col"} "Check"]
+         [:th {:scope "col"} "Actual vs threshold"]
+         [:th {:scope "col"} "Status"]]]
+       [:tbody
+        (for [{:keys [key label comparison passes?]} checks]
+          ^{:key key}
+          [:tr
+           [:th {:scope "row"} label]
+           [:td comparison]
+           [:td {:class (if passes? "pf-status-pass" "pf-status-fail")}
+            (if passes? "PASS ✓" "FAIL ✕")]])]]]
+     [:button.pf-gate-reset
+      {:type "button" :on-click reset-gate! :disabled (not counterfactual?)}
+      "Reset historical thresholds"]]))
+
 (def styles
-  ".pf-controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,13rem),1fr));gap:.8rem;align-items:end}.pf-control{display:grid;gap:.3rem;min-width:0}.pf-control input{width:100%;min-width:0}.pf-button{border:1px solid #1464b5;border-radius:.4rem;padding:.6rem .9rem;background:#1464b5;color:#fff;font-weight:700;cursor:pointer}.pf-button:disabled{opacity:.6;cursor:wait}.pf-button:focus-visible,.pf-control input:focus-visible{outline:3px solid color-mix(in srgb,#2780e3 45%,transparent);outline-offset:2px}.pf-live{font-variant-numeric:tabular-nums}.pf-lab svg{display:block;width:100%;height:auto}.pf-note{font-size:.88rem;color:#4f5b66}.quarto-dark .pf-note{color:#b9c7d2}.pf-summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,12rem),1fr));gap:.8rem;margin-top:1rem}.pf-summary-grid section{min-width:0;border:1px solid #dee2e6;border-radius:.45rem;padding:.7rem}.pf-summary-grid h4{font-size:.95rem;margin:0 0 .3rem}.pf-summary-grid p{margin:.2rem 0}")
+  (str
+   ".pf-controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,13rem),1fr));gap:.8rem;align-items:end}.pf-control{display:grid;gap:.3rem;min-width:0}.pf-control input{width:100%;min-width:0;accent-color:var(--pf-accent,#1464b5)}"
+   ".pf-button{border:1px solid var(--pf-accent,#1464b5);border-radius:.4rem;padding:.6rem .9rem;background:var(--pf-accent,#1464b5);color:var(--bs-body-bg,#fff);font-weight:700;cursor:pointer}.quarto-dark .pf-button{color:#10212b}.pf-button:disabled{opacity:.6;cursor:wait}"
+   ".pf-button:focus-visible,.pf-control input:focus-visible,.pf-gate-field input:focus-visible,.pf-gate-reset:focus-visible{outline:3px solid color-mix(in srgb,var(--pf-accent,#2780e3) 50%,transparent);outline-offset:2px}.pf-live{font-variant-numeric:tabular-nums}.pf-lab svg{display:block;width:100%;height:auto}.pf-note{font-size:.88rem;color:var(--pf-muted,#4f5b66)}"
+   ".pf-summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,12rem),1fr));gap:.8rem;margin-top:1rem}.pf-summary-grid section{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.7rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.pf-summary-grid h4{font-size:.95rem;margin:0 0 .3rem}.pf-summary-grid p{margin:.2rem 0}"
+   ".pf-response-shell{min-width:0;border:1px solid var(--bs-border-color,#ced4da);border-radius:.65rem;padding:clamp(.8rem,3vw,1.3rem);margin:1.25rem 0;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.pf-response-shell h3{margin-top:0}.pf-response-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:.55rem;margin:1rem 0}.pf-response-card{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.65rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 94%,var(--pf-accent,#1464b5) 6%);overflow-wrap:anywhere}.pf-response-card strong,.pf-response-card span,.pf-response-card small{display:block}.pf-response-card small{color:var(--pf-muted,#4f5b66);margin-top:.25rem}.pf-response-progress{width:100%;height:.55rem;accent-color:var(--pf-accent,#1464b5)}.pf-response-effects{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.65rem;margin:.85rem 0}.pf-response-effect{min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-left:4px solid var(--pf-accent,#1464b5);border-radius:.45rem;padding:.65rem;background:color-mix(in srgb,var(--bs-body-bg,#fff) 92%,var(--pf-accent,#1464b5) 8%);overflow-wrap:anywhere}.pf-response-effect.is-fixed{border-left-color:var(--pf-success,#0f695f);background:color-mix(in srgb,var(--bs-body-bg,#fff) 92%,var(--pf-success,#0f695f) 8%)}.pf-response-effect strong,.pf-response-effect span,.pf-response-effect small{display:block}.pf-response-effect small{color:var(--pf-muted,#4f5b66);margin-top:.25rem}.pf-response-status{min-height:2.8rem;font-variant-numeric:tabular-nums}.pf-response-actions{display:flex;gap:.5rem;flex-wrap:wrap}.pf-response-button{border:1px solid var(--bs-border-color,#6c757d);border-radius:.35rem;padding:.55rem .85rem;font-weight:700;cursor:pointer;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.pf-response-button.is-primary{border-color:var(--pf-accent,#1464b5);background:var(--pf-accent,#1464b5);color:#fff}.quarto-dark .pf-response-button.is-primary{color:#10212b}.pf-response-button:disabled{opacity:.5;cursor:not-allowed}.pf-response-button:focus-visible{outline:3px solid color-mix(in srgb,var(--pf-accent,#1464b5) 50%,transparent);outline-offset:2px}"
+   ".pf-gate-shell{min-width:0}.pf-gate-shell h3{margin-top:0}.pf-gate-banner{display:grid;gap:.25rem;border:2px solid var(--pf-fail,#a72f24);border-left-width:6px;border-radius:.45rem;padding:.8rem .9rem;margin:.7rem 0;background:color-mix(in srgb,var(--bs-body-bg,#fff) 86%,var(--pf-fail,#a72f24) 14%);color:var(--bs-body-color,#212529)}.pf-gate-banner.is-counterfactual{border-color:var(--pf-warn,#8a5000);background:color-mix(in srgb,var(--bs-body-bg,#fff) 84%,var(--pf-warn,#8a5000) 16%)}"
+   ".pf-gate-controls{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,14rem),1fr));gap:.7rem;margin:1rem 0}.pf-gate-field{display:grid;gap:.4rem;min-width:0;border:1px solid var(--bs-border-color,#dee2e6);border-radius:.45rem;padding:.7rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529)}.pf-gate-field>div{display:flex;justify-content:space-between;align-items:baseline;gap:.55rem;flex-wrap:wrap}.pf-gate-field label{font-weight:700}.pf-gate-field output{font-variant-numeric:tabular-nums;color:var(--pf-muted,#4f5b66)}.pf-gate-field input{width:100%;min-width:0;accent-color:var(--pf-accent,#1464b5)}"
+   ".pf-gate-table td:nth-child(2){font-variant-numeric:tabular-nums}.pf-gate-reset{border:1px solid var(--pf-accent,#1464b5);border-radius:.4rem;padding:.55rem .8rem;background:var(--bs-body-bg,#fff);color:var(--bs-body-color,#212529);font-weight:700;cursor:pointer}.pf-gate-reset:disabled{opacity:.55;cursor:not-allowed}"
+   "@media(max-width:767px){.pf-response-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:575px){.pf-gate-table th,.pf-gate-table td{white-space:normal;min-width:7rem}.pf-response-effects{grid-template-columns:minmax(0,1fr)}}@media(max-width:400px){.pf-response-grid{grid-template-columns:minmax(0,1fr)}}"))
 
 (let [style (.createElement js/document "style")]
   (set! (.-textContent style) styles)
   (.appendChild (.-head js/document) style))
 
-(rdom/render [curve-explorer]
-             (.getElementById js/document "pair-frequency-curve-explorer"))
-(rdom/render [simulation-lab]
-             (.getElementById js/document "pair-frequency-simulation-lab"))
+(defn mount! [id component]
+  (when-let [element (.getElementById js/document id)]
+    (rdom/render [component] element)))
+
+(when (seq xs)
+  (mount! "pair-frequency-curve-explorer" curve-explorer)
+  (mount! "pair-frequency-simulation-lab" simulation-lab))
+
+(mount! "pair-frequency-response-inference-simulator"
+        response-inference-simulator)
+
+(when gate-data
+  (mount! "pair-frequency-gate-inspector" gate-inspector))


### PR DESCRIPTION
## Summary

- publish three executable vocabulary-estimation tutorials, including the negative continuous-frequency model result
- add deterministic fixtures, CLJ and CLJS parity tests, shared reading controls, and interactive teaching tools
- add Civitas-styled Clay live preview support

## Tests

- clojure -M:test-clj: 14 tests, 58 assertions
- clojure -M:test-cljs: 10 tests, 45 assertions
- focused Clay and Quarto renders for all three articles
- internal-browser light and dark, mobile, control, navigation, and console checks
- quarto render site: 230 of 230 pages, exit 0