### PR TITLE
Remove redundant vocabulary ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,6 @@ _site/
 !/site/_quarto.yml
 !/site/_extensions/
 !/site/_extensions/**
-!/site/language_learning/
-!/site/language_learning/vocabulary_estimation/
-/site/language_learning/vocabulary_estimation/*
-!/site/language_learning/vocabulary_estimation/_metadata.yml
 
 # Janqua nREPL lifecycle files (created in the Quarto rendering directory)
 .jank-pid


### PR DESCRIPTION
## Summary

- remove the vocabulary-specific ignore exception block
- rely on the existing /site/* rule for generated vocabulary outputs
- keep the tracked vocabulary _metadata.yml unchanged

## Verification

- confirmed all 12 generated .qmd, .cljs, and .cljc files remain ignored
- confirmed site/language_learning/vocabulary_estimation/_metadata.yml remains tracked
- git diff --check passes